### PR TITLE
fix: decouple from app version, fix nodetool-core API drift

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,18 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nodetool-huggingface"
-version = "0.6.3-rc.47"
+version = "0.7.0-rc.8"
 description = "HuggingFace nodes for Nodetool"
 readme = "README.md"
 authors = [{ name = "Matthias Georgi", email = "matti.georgi@gmail.com" }]
 requires-python = ">=3.11"
 
 dependencies = [
-    "nodetool-core==0.6.3-rc.47",
+    # Lower bound only — let uv resolve to whatever published nodetool-core
+    # works with the rest of the user's environment. Bump this lower bound
+    # only when relying on a new nodetool-core API. See
+    # https://github.com/nodetool-ai/nodetool/blob/main/packages/runtime/src/bridge-protocol.ts
+    "nodetool-core>=0.7.0rc8",
     "torch==2.9.0",
     "nunchaku ; platform_system != 'Darwin'",
     "torchsde",

--- a/src/nodetool/huggingface/huggingface_local_provider.py
+++ b/src/nodetool/huggingface/huggingface_local_provider.py
@@ -53,7 +53,6 @@ from nodetool.huggingface.local_provider_utils import (
 from nodetool.huggingface.text_to_image_pipelines import (
     load_text_to_image_pipeline,
 )
-from nodetool.types.job import JobUpdate
 from nodetool.types.model import UnifiedModel
 from nodetool.workflows.processing_context import ProcessingContext
 from nodetool.metadata.types import (
@@ -68,7 +67,7 @@ from nodetool.metadata.types import (
     LanguageModel,
     VideoRef,
 )
-from nodetool.workflows.types import Chunk, NodeProgress
+from nodetool.workflows.types import Chunk, JobUpdate, NodeProgress
 from nodetool.config.logging_config import get_logger
 from nodetool.ml.core.model_manager import ModelManager
 from nodetool.io.media_fetch import fetch_uri_bytes_and_mime_async

--- a/src/nodetool/huggingface/huggingface_local_provider.py
+++ b/src/nodetool/huggingface/huggingface_local_provider.py
@@ -67,7 +67,7 @@ from nodetool.metadata.types import (
     LanguageModel,
     VideoRef,
 )
-from nodetool.workflows.types import Chunk, JobUpdate, NodeProgress
+from nodetool.workflows.types import Chunk, NodeProgress
 from nodetool.config.logging_config import get_logger
 from nodetool.ml.core.model_manager import ModelManager
 from nodetool.io.media_fetch import fetch_uri_bytes_and_mime_async

--- a/src/nodetool/huggingface/local_provider_utils.py
+++ b/src/nodetool/huggingface/local_provider_utils.py
@@ -12,9 +12,8 @@ from typing import Any, TypeVar, TYPE_CHECKING
 from nodetool.config.logging_config import get_logger
 from nodetool.integrations.huggingface.huggingface_models import HF_FAST_CACHE
 from nodetool.ml.core.model_manager import ModelManager
-from nodetool.types.job import JobUpdate
 from nodetool.workflows.processing_context import ProcessingContext
-from nodetool.workflows.types import NodeProgress
+from nodetool.workflows.types import JobUpdate, NodeProgress
 from huggingface_hub import _CACHED_NO_EXIST, hf_hub_download
 
 if TYPE_CHECKING:


### PR DESCRIPTION
- Update imports: JobUpdate moved from nodetool.types.job (removed in newer nodetool-core) to nodetool.workflows.types. Without this, importing nodetool-huggingface against current nodetool-core fails with ModuleNotFoundError, which silently breaks the Electron stdio bridge.
- Relax pyproject pin: nodetool-core==0.6.3-rc.47 ->
  nodetool-core>=0.7.0rc8. The hard equality previously forced uv to downgrade nodetool-core during install, undoing whatever the app installer requested. Lower bound only — bump it when relying on a new nodetool-core API.
- Bump version to 0.7.0-rc.8 for the next publish so the registry has a wheel compatible with the new bridge protocol.