### PR TITLE
Add new pipeline nodes and model updates from HuggingFace research

### DIFF
--- a/src/nodetool/nodes/huggingface/depth_estimation.py
+++ b/src/nodetool/nodes/huggingface/depth_estimation.py
@@ -50,6 +50,15 @@ class DepthEstimation(HuggingFacePipelineNode):
                     "txt",
                 ],
             ),
+            HFDepthEstimation(
+                repo_id="apple/DepthPro-hf",
+            ),
+            HFDepthEstimation(
+                repo_id="depth-anything/Depth-Anything-V2-Metric-Indoor-Small-hf",
+            ),
+            HFDepthEstimation(
+                repo_id="depth-anything/Depth-Anything-V2-Metric-Outdoor-Small-hf",
+            ),
         ]
 
     def required_inputs(self):

--- a/src/nodetool/nodes/huggingface/document_question_answering.py
+++ b/src/nodetool/nodes/huggingface/document_question_answering.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from typing import Any
+
+from nodetool.metadata.types import HuggingFaceModel, ImageRef
+from nodetool.nodes.huggingface.huggingface_pipeline import (
+    HuggingFacePipelineNode,
+    select_inference_dtype,
+)
+from nodetool.workflows.processing_context import ProcessingContext
+
+from pydantic import Field
+
+
+class DocumentQuestionAnswering(HuggingFacePipelineNode):
+    """
+    Answers natural language questions about document images (PDFs, receipts, forms, invoices).
+    document, QA, question-answering, OCR, LayoutLM, Donut, vision-language
+
+    Use cases:
+    - Extract structured data from scanned invoices, receipts, and forms
+    - Query PDF documents by natural language without manual parsing
+    - Automate data entry from paper-based documents
+    - Build intelligent document processing pipelines
+    - Answer questions about tables, charts, and mixed-layout documents
+    """
+
+    model: HuggingFaceModel = Field(
+        default=HuggingFaceModel(repo_id="impira/layoutlm-document-qa"),
+        title="Model",
+        description="The document QA model. LayoutLM variants combine text and layout understanding; Donut models are OCR-free and more robust to noisy scans.",
+    )
+    image: ImageRef = Field(
+        default=ImageRef(),
+        title="Document Image",
+        description="The document image to query (scan, screenshot, photo of a form or invoice).",
+    )
+    question: str = Field(
+        default="",
+        title="Question",
+        description="The natural language question to answer about the document (e.g. 'What is the total amount?', 'Who is the sender?').",
+    )
+
+    _pipeline: Any = None
+
+    @classmethod
+    def get_recommended_models(cls) -> list[HuggingFaceModel]:
+        return [
+            HuggingFaceModel(
+                repo_id="impira/layoutlm-document-qa",
+                allow_patterns=["README.md", "*.bin", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="impira/layoutlm-invoices",
+                allow_patterns=["README.md", "*.bin", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="naver-clova-ix/donut-base-finetuned-docvqa",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="naver-clova-ix/donut-base-finetuned-rvlcdip",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="microsoft/layoutlmv3-base",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="cloudqi/cqi_visual_question_answering_pt_v0",
+                allow_patterns=["README.md", "*.bin", "*.json", "**/*.json"],
+            ),
+        ]
+
+    def required_inputs(self):
+        return ["image", "question"]
+
+    @classmethod
+    def get_title(cls) -> str:
+        return "Document Question Answering"
+
+    def get_model_id(self):
+        return self.model.repo_id
+
+    async def move_to_device(self, device: str):
+        if self._pipeline is not None:
+            self._pipeline.model.to(device)
+
+    async def preload_model(self, context: ProcessingContext):
+        self._pipeline = await self.load_pipeline(
+            context=context,
+            pipeline_task="document-question-answering",
+            model_id=self.get_model_id(),
+            device=context.device,
+            torch_dtype=select_inference_dtype(),
+        )
+
+    async def process(self, context: ProcessingContext) -> str:
+        assert self._pipeline is not None
+        image = await context.image_to_pil(self.image)
+        result = await self.run_pipeline_in_thread(
+            image=image,
+            question=self.question,
+        )
+        if isinstance(result, list) and len(result) > 0:
+            return str(result[0].get("answer", ""))
+        if isinstance(result, dict):
+            return str(result.get("answer", ""))
+        return str(result)

--- a/src/nodetool/nodes/huggingface/image_segmentation.py
+++ b/src/nodetool/nodes/huggingface/image_segmentation.py
@@ -201,6 +201,11 @@ class MaskGeneration(HuggingFacePipelineNode):
     - Create training data annotations automatically
     """
 
+    model: HuggingFaceModel = Field(
+        default=HuggingFaceModel(repo_id="facebook/sam2.1-hiera-large"),
+        title="Model",
+        description="The SAM model to use. SAM2.1/SAM3 offer best quality; SAM-ViT-base is fastest.",
+    )
     image: ImageRef = Field(
         default=ImageRef(),
         title="Input Image",
@@ -254,13 +259,13 @@ class MaskGeneration(HuggingFacePipelineNode):
         return "Mask Generation (SAM)"
 
     def get_model_id(self):
-        return self.model.repo_id if hasattr(self, "model") else "facebook/sam2.1-hiera-large"
+        return self.model.repo_id
 
     async def preload_model(self, context: ProcessingContext):
         self._pipeline = await self.load_pipeline(
             context=context,
             pipeline_task="mask-generation",
-            model_id="facebook/sam2.1-hiera-large",
+            model_id=self.get_model_id(),
             device=context.device,
         )
 

--- a/src/nodetool/nodes/huggingface/image_segmentation.py
+++ b/src/nodetool/nodes/huggingface/image_segmentation.py
@@ -125,6 +125,15 @@ class SAM2Segmentation(HuggingFacePipelineNode):
             HuggingFaceModel(
                 repo_id="facebook/sam2-hiera-large",
             ),
+            HuggingFaceModel(
+                repo_id="facebook/sam2-hiera-base-plus",
+            ),
+            HuggingFaceModel(
+                repo_id="facebook/sam2.1-hiera-large",
+            ),
+            HuggingFaceModel(
+                repo_id="facebook/sam3",
+            ),
         ]
 
     def required_inputs(self):
@@ -177,6 +186,104 @@ class SAM2Segmentation(HuggingFacePipelineNode):
                 result.append(mask_ref)
 
             return result
+
+
+class MaskGeneration(HuggingFacePipelineNode):
+    """
+    Generates segmentation masks for all objects in an image using the SAM/SAM2/SAM3 mask-generation pipeline.
+    image, segmentation, mask-generation, SAM, SAM2, SAM3, zero-shot
+
+    Use cases:
+    - Automatically generate masks for every object in an image without prompts
+    - Prepare masks for downstream editing, compositing, or inpainting
+    - Build interactive object selection tools
+    - Enable instance-level image understanding without class labels
+    - Create training data annotations automatically
+    """
+
+    image: ImageRef = Field(
+        default=ImageRef(),
+        title="Input Image",
+        description="The image for which to generate segmentation masks.",
+    )
+    points_per_side: int = Field(
+        default=32,
+        title="Points Per Side",
+        description="Number of grid points to sample along each image dimension. Higher = more masks found but slower.",
+        ge=8,
+        le=128,
+    )
+    pred_iou_thresh: float = Field(
+        default=0.88,
+        title="Predicted IoU Threshold",
+        description="Masks with predicted IoU below this threshold are filtered out. Higher = fewer, higher-quality masks.",
+        ge=0.0,
+        le=1.0,
+    )
+
+    _pipeline: Any = None
+
+    @classmethod
+    def get_recommended_models(cls) -> list[HuggingFaceModel]:
+        return [
+            HuggingFaceModel(
+                repo_id="facebook/sam2.1-hiera-large",
+            ),
+            HuggingFaceModel(
+                repo_id="facebook/sam2.1-hiera-base-plus",
+            ),
+            HuggingFaceModel(
+                repo_id="facebook/sam3",
+            ),
+            HuggingFaceModel(
+                repo_id="facebook/sam-vit-huge",
+            ),
+            HuggingFaceModel(
+                repo_id="facebook/sam-vit-large",
+            ),
+            HuggingFaceModel(
+                repo_id="facebook/sam-vit-base",
+            ),
+        ]
+
+    def required_inputs(self):
+        return ["image"]
+
+    @classmethod
+    def get_title(cls) -> str:
+        return "Mask Generation (SAM)"
+
+    def get_model_id(self):
+        return self.model.repo_id if hasattr(self, "model") else "facebook/sam2.1-hiera-large"
+
+    async def preload_model(self, context: ProcessingContext):
+        self._pipeline = await self.load_pipeline(
+            context=context,
+            pipeline_task="mask-generation",
+            model_id="facebook/sam2.1-hiera-large",
+            device=context.device,
+        )
+
+    async def move_to_device(self, device: str):
+        if self._pipeline is not None:
+            self._pipeline.model.to(device)
+
+    async def process(self, context: ProcessingContext) -> list[ImageRef]:
+        assert self._pipeline is not None
+        import numpy as np
+
+        image = await context.image_to_pil(self.image)
+        result = await self.run_pipeline_in_thread(
+            image,
+            points_per_side=self.points_per_side,
+            pred_iou_thresh=self.pred_iou_thresh,
+        )
+
+        masks_out = []
+        for mask_data in result.get("masks", []):
+            mask_np = (np.array(mask_data) * 255).astype("uint8")
+            masks_out.append(await context.image_from_numpy(mask_np))
+        return masks_out
 
 
 class FindSegment(BaseNode):

--- a/src/nodetool/nodes/huggingface/image_text_to_text.py
+++ b/src/nodetool/nodes/huggingface/image_text_to_text.py
@@ -210,6 +210,45 @@ class ImageTextToText(HuggingFacePipelineNode):
             HFImageTextToText(
                 repo_id="zai-org/GLM-4.6V-Flash",
             ),
+            # Florence-2: multi-task vision (captioning, detection, grounding, OCR)
+            HFImageTextToText(
+                repo_id="microsoft/Florence-2-base",
+                allow_patterns=["*.safetensors", "*.json", "*.txt"],
+            ),
+            HFImageTextToText(
+                repo_id="microsoft/Florence-2-large",
+                allow_patterns=["*.safetensors", "*.json", "*.txt"],
+            ),
+            HFImageTextToText(
+                repo_id="microsoft/Florence-2-base-ft",
+                allow_patterns=["*.safetensors", "*.json", "*.txt"],
+            ),
+            HFImageTextToText(
+                repo_id="microsoft/Florence-2-large-ft",
+                allow_patterns=["*.safetensors", "*.json", "*.txt"],
+            ),
+            # Phi-4 multimodal
+            HFImageTextToText(
+                repo_id="microsoft/Phi-4-multimodal-instruct",
+            ),
+            # SmolVLM variants
+            HFImageTextToText(
+                repo_id="HuggingFaceTB/SmolVLM2-2.2B-Instruct",
+            ),
+            HFImageTextToText(
+                repo_id="HuggingFaceTB/SmolVLM2-500M-Video-Instruct",
+            ),
+            # InternVL2 series
+            HFImageTextToText(
+                repo_id="OpenGVLab/InternVL2_5-8B",
+            ),
+            HFImageTextToText(
+                repo_id="OpenGVLab/InternVL2_5-4B",
+            ),
+            # Idefics3
+            HFImageTextToText(
+                repo_id="HuggingFaceM4/Idefics3-8B-Llama3",
+            ),
         ]
 
     @classmethod

--- a/src/nodetool/nodes/huggingface/image_to_video.py
+++ b/src/nodetool/nodes/huggingface/image_to_video.py
@@ -280,3 +280,169 @@ class Wan_I2V(HuggingFacePipelineNode):
 
     def required_inputs(self):
         return ["input_image"]
+
+
+class Wan_FLF2V(HuggingFacePipelineNode):
+    """
+    Generates smooth video transitions between a first and last frame using Wan FLF2V.
+    video, generation, AI, image-to-video, first-last-frame, interpolation, diffusion, Wan
+
+    Use cases:
+    - Create seamless transitions between two keyframe images
+    - Animate the journey from one scene to another
+    - Generate motion-filled clips from start and end frames
+    - Build scene interpolation workflows for film and VFX
+    - Produce smooth morphing effects for creative projects
+    """
+
+    first_image: ImageRef = Field(
+        default=ImageRef(),
+        description="The first frame (starting image) for the video transition.",
+    )
+    last_image: ImageRef = Field(
+        default=ImageRef(),
+        description="The last frame (ending image) for the video transition.",
+    )
+    prompt: str = Field(
+        default="A smooth transition between the two scenes, cinematic motion",
+        description="Text description guiding the motion and style of the generated transition.",
+    )
+    negative_prompt: str = Field(
+        default="",
+        description="Describe what to avoid in the generated video (e.g., 'blurry, distorted').",
+    )
+    num_frames: int = Field(
+        default=81,
+        description="Total frames in the output video. More frames = longer duration.",
+        ge=16,
+        le=129,
+    )
+    guidance_scale: float = Field(
+        default=5.0,
+        description="How strongly to follow the prompt.",
+        ge=1.0,
+        le=20.0,
+    )
+    num_inference_steps: int = Field(
+        default=50,
+        description="Denoising steps. More steps = better quality but slower.",
+        ge=1,
+        le=100,
+    )
+    height: int = Field(
+        default=480,
+        description="Output video height in pixels.",
+        ge=256,
+        le=1080,
+    )
+    width: int = Field(
+        default=832,
+        description="Output video width in pixels.",
+        ge=256,
+        le=1920,
+    )
+    fps: int = Field(
+        default=16,
+        description="Frames per second for the output video file.",
+        ge=1,
+        le=60,
+    )
+    seed: int = Field(
+        default=-1,
+        description="Random seed for reproducibility. Use -1 for random.",
+        ge=-1,
+    )
+    enable_cpu_offload: bool = Field(
+        default=True,
+        description="Offload model components to CPU to reduce VRAM usage.",
+    )
+
+    _pipeline: Any = None
+
+    @classmethod
+    def get_recommended_models(cls) -> list[HuggingFaceModel]:
+        return [
+            HFTextToVideo(
+                repo_id="Wan-AI/Wan2.2-FLF2V-14B-720P-Diffusers",
+                allow_patterns=["**/*.safetensors", "**/*.json", "**/*.txt", "*.json"],
+            ),
+            HFTextToVideo(
+                repo_id="Wan-AI/Wan2.1-FLF2V-14B-720P-diffusers",
+                allow_patterns=["**/*.safetensors", "**/*.json", "**/*.txt", "*.json"],
+            ),
+        ]
+
+    @classmethod
+    def get_title(cls) -> str:
+        return "Wan (First-Last-Frame to Video)"
+
+    @classmethod
+    def get_basic_fields(cls) -> list[str]:
+        return ["first_image", "last_image", "prompt", "num_frames", "height", "width"]
+
+    def get_model_id(self) -> str:
+        return "Wan-AI/Wan2.2-FLF2V-14B-720P-Diffusers"
+
+    def required_inputs(self):
+        return ["first_image", "last_image"]
+
+    async def preload_model(self, context: ProcessingContext):
+        from diffusers.pipelines.wan.pipeline_wan_flf2v import WanFLF2VPipeline
+        from nodetool.nodes.huggingface.stable_diffusion_base import available_torch_dtype
+
+        torch_dtype = available_torch_dtype()
+        self._pipeline = await self.load_model(
+            context=context,
+            model_class=WanFLF2VPipeline,
+            model_id=self.get_model_id(),
+            torch_dtype=torch_dtype,
+            variant=None,
+        )
+        if self.enable_cpu_offload:
+            self._pipeline.enable_model_cpu_offload()
+
+    async def move_to_device(self, device: str):
+        if self._pipeline is not None and not self.enable_cpu_offload:
+            self._pipeline.to(device)
+
+    async def process(self, context: ProcessingContext) -> VideoRef:
+        if self._pipeline is None:
+            raise ValueError("Pipeline not initialized")
+
+        import torch
+
+        first_frame = await context.image_to_pil(self.first_image)
+        last_frame = await context.image_to_pil(self.last_image)
+
+        generator = None
+        if self.seed != -1:
+            generator = torch.Generator(device="cpu").manual_seed(self.seed)
+
+        def callback_on_step_end(
+            pipeline: Any, step_index: int, timesteps: int, callback_kwargs: dict
+        ) -> dict:
+            context.post_message(
+                NodeProgress(
+                    node_id=self.id,
+                    progress=step_index,
+                    total=self.num_inference_steps,
+                )
+            )
+            return callback_kwargs
+
+        output = await self.run_pipeline_in_thread(
+            image=first_frame,
+            last_image=last_frame,
+            prompt=self.prompt,
+            negative_prompt=self.negative_prompt,
+            height=self.height,
+            width=self.width,
+            num_frames=self.num_frames,
+            guidance_scale=self.guidance_scale,
+            num_inference_steps=self.num_inference_steps,
+            generator=generator,
+            callback_on_step_end=callback_on_step_end,
+        )
+
+        run_gc("After Wan FLF2V inference", log_before_after=False)
+        return await video_from_frames(context, output.frames[0], fps=self.fps)

--- a/src/nodetool/nodes/huggingface/image_to_video.py
+++ b/src/nodetool/nodes/huggingface/image_to_video.py
@@ -295,6 +295,14 @@ class Wan_FLF2V(HuggingFacePipelineNode):
     - Produce smooth morphing effects for creative projects
     """
 
+    class WanFLF2VModel(str, Enum):
+        WAN_2_2_FLF2V_14B_720P = "Wan-AI/Wan2.2-FLF2V-14B-720P-Diffusers"
+        WAN_2_1_FLF2V_14B_720P = "Wan-AI/Wan2.1-FLF2V-14B-720P-diffusers"
+
+    model_variant: WanFLF2VModel = Field(
+        default=WanFLF2VModel.WAN_2_2_FLF2V_14B_720P,
+        description="The Wan FLF2V model variant. 2.2 is the latest; 2.1 is the previous generation.",
+    )
     first_image: ImageRef = Field(
         default=ImageRef(),
         description="The first frame (starting image) for the video transition.",
@@ -381,7 +389,7 @@ class Wan_FLF2V(HuggingFacePipelineNode):
         return ["first_image", "last_image", "prompt", "num_frames", "height", "width"]
 
     def get_model_id(self) -> str:
-        return "Wan-AI/Wan2.2-FLF2V-14B-720P-Diffusers"
+        return self.model_variant.value
 
     def required_inputs(self):
         return ["first_image", "last_image"]

--- a/src/nodetool/nodes/huggingface/summarization.py
+++ b/src/nodetool/nodes/huggingface/summarization.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from typing import Any
 
 from nodetool.metadata.types import HuggingFaceModel
-from nodetool.nodes.huggingface.huggingface_pipeline import HuggingFacePipelineNode
+from nodetool.nodes.huggingface.huggingface_pipeline import (
+    HuggingFacePipelineNode,
+    select_inference_dtype,
+)
 from nodetool.workflows.processing_context import ProcessingContext
 
 from pydantic import Field
@@ -115,6 +118,7 @@ class Summarization(HuggingFacePipelineNode):
             pipeline_task="summarization",
             model_id=self.get_model_id(),
             device=context.device,
+            torch_dtype=select_inference_dtype(),
         )
 
     async def process(self, context: ProcessingContext) -> str:

--- a/src/nodetool/nodes/huggingface/summarization.py
+++ b/src/nodetool/nodes/huggingface/summarization.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from typing import Any
+
+from nodetool.metadata.types import HuggingFaceModel
+from nodetool.nodes.huggingface.huggingface_pipeline import HuggingFacePipelineNode
+from nodetool.workflows.processing_context import ProcessingContext
+
+from pydantic import Field
+
+
+class Summarization(HuggingFacePipelineNode):
+    """
+    Condenses long documents or articles into concise summaries using seq2seq models.
+    text, summarization, NLP, BART, T5, PEGASUS, document-understanding
+
+    Use cases:
+    - Summarize news articles, research papers, or legal documents
+    - Generate executive summaries for long reports
+    - Create TL;DR versions of long-form content
+    - Extract key points from meeting transcripts or call recordings
+    - Build document digest pipelines for knowledge management
+    """
+
+    model: HuggingFaceModel = Field(
+        default=HuggingFaceModel(repo_id="facebook/bart-large-cnn"),
+        title="Model",
+        description="The summarization model. BART-large-CNN excels at news; PEGASUS variants work well across domains; DistilBART is faster with comparable quality.",
+    )
+    text: str = Field(
+        default="",
+        title="Text",
+        description="The text to summarize. Works best with at least a few sentences; very short inputs may produce poor results.",
+    )
+    max_length: int = Field(
+        default=130,
+        title="Max Length",
+        description="Maximum token length of the generated summary.",
+        ge=10,
+        le=1024,
+    )
+    min_length: int = Field(
+        default=30,
+        title="Min Length",
+        description="Minimum token length of the generated summary.",
+        ge=5,
+        le=512,
+    )
+    do_sample: bool = Field(
+        default=False,
+        title="Do Sample",
+        description="Enable sampling for more varied outputs. Disable for deterministic, beam-search summaries.",
+    )
+
+    _pipeline: Any = None
+
+    @classmethod
+    def get_recommended_models(cls) -> list[HuggingFaceModel]:
+        return [
+            HuggingFaceModel(
+                repo_id="facebook/bart-large-cnn",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="facebook/bart-large-xsum",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="sshleifer/distilbart-cnn-12-6",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="sshleifer/distilbart-xsum-12-6",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="google/pegasus-xsum",
+                allow_patterns=["README.md", "*.bin", "*.json", "**/*.json", "*.txt"],
+            ),
+            HuggingFaceModel(
+                repo_id="google/pegasus-cnn_dailymail",
+                allow_patterns=["README.md", "*.bin", "*.json", "**/*.json", "*.txt"],
+            ),
+            HuggingFaceModel(
+                repo_id="t5-small",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="t5-base",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="philschmid/bart-large-cnn-samsum",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+        ]
+
+    def required_inputs(self):
+        return ["text"]
+
+    @classmethod
+    def get_title(cls) -> str:
+        return "Summarization"
+
+    def get_model_id(self):
+        return self.model.repo_id
+
+    async def move_to_device(self, device: str):
+        if self._pipeline is not None:
+            self._pipeline.model.to(device)
+
+    async def preload_model(self, context: ProcessingContext):
+        self._pipeline = await self.load_pipeline(
+            context=context,
+            pipeline_task="summarization",
+            model_id=self.get_model_id(),
+            device=context.device,
+        )
+
+    async def process(self, context: ProcessingContext) -> str:
+        assert self._pipeline is not None
+        result = await self.run_pipeline_in_thread(
+            self.text,
+            max_length=self.max_length,
+            min_length=self.min_length,
+            do_sample=self.do_sample,
+        )
+        return str(result[0]["summary_text"])

--- a/src/nodetool/nodes/huggingface/text2text_generation.py
+++ b/src/nodetool/nodes/huggingface/text2text_generation.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from typing import Any
+
+from nodetool.metadata.types import HuggingFaceModel
+from nodetool.nodes.huggingface.huggingface_pipeline import HuggingFacePipelineNode
+from nodetool.workflows.processing_context import ProcessingContext
+
+from pydantic import Field
+
+
+class Text2TextGeneration(HuggingFacePipelineNode):
+    """
+    Transforms input text into output text using seq2seq models (T5, FLAN-T5, mT5).
+    text, generation, NLP, seq2seq, T5, FLAN-T5, translation, QA
+
+    Use cases:
+    - Instruction-following tasks with FLAN-T5 (e.g. "Translate to French: Hello")
+    - Grammar correction and text reformatting
+    - Question answering in generative form
+    - Code generation and transformation
+    - Cross-lingual text generation with multilingual models (mT5)
+    """
+
+    model: HuggingFaceModel = Field(
+        default=HuggingFaceModel(repo_id="google/flan-t5-base"),
+        title="Model",
+        description="The seq2seq model to use. FLAN-T5 variants are instruction-tuned and handle diverse tasks; T5 is versatile; mT5 supports 100+ languages.",
+    )
+    text: str = Field(
+        default="",
+        title="Input Text",
+        description="The input text or instruction. For FLAN-T5 prefix with task description (e.g. 'Summarize: ...', 'Translate to German: ...').",
+    )
+    max_new_tokens: int = Field(
+        default=200,
+        title="Max New Tokens",
+        description="Maximum number of tokens to generate in the output.",
+        ge=1,
+        le=2048,
+    )
+    temperature: float = Field(
+        default=1.0,
+        title="Temperature",
+        description="Controls randomness. Lower values (0.1-0.5) give more focused outputs; higher values (>1.0) increase creativity.",
+        ge=0.0,
+        le=2.0,
+    )
+    do_sample: bool = Field(
+        default=False,
+        title="Do Sample",
+        description="Enable sampling. Disable for deterministic beam-search decoding.",
+    )
+
+    _pipeline: Any = None
+
+    @classmethod
+    def get_recommended_models(cls) -> list[HuggingFaceModel]:
+        return [
+            HuggingFaceModel(
+                repo_id="google/flan-t5-small",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="google/flan-t5-base",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="google/flan-t5-large",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="google/flan-t5-xl",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="google/flan-t5-xxl",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="google/t5-v1_1-base",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="google/t5-v1_1-large",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="google/mt5-base",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json", "*.txt"],
+            ),
+            HuggingFaceModel(
+                repo_id="google/mt5-large",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json", "*.txt"],
+            ),
+            HuggingFaceModel(
+                repo_id="Salesforce/codet5-base",
+                allow_patterns=["README.md", "*.bin", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="Salesforce/codet5p-220m",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+        ]
+
+    def required_inputs(self):
+        return ["text"]
+
+    @classmethod
+    def get_title(cls) -> str:
+        return "Text-to-Text Generation"
+
+    def get_model_id(self):
+        return self.model.repo_id
+
+    async def move_to_device(self, device: str):
+        if self._pipeline is not None:
+            self._pipeline.model.to(device)
+
+    async def preload_model(self, context: ProcessingContext):
+        self._pipeline = await self.load_pipeline(
+            context=context,
+            pipeline_task="text2text-generation",
+            model_id=self.get_model_id(),
+            device=context.device,
+        )
+
+    async def process(self, context: ProcessingContext) -> str:
+        assert self._pipeline is not None
+        result = await self.run_pipeline_in_thread(
+            self.text,
+            max_new_tokens=self.max_new_tokens,
+            temperature=self.temperature if self.do_sample else None,
+            do_sample=self.do_sample,
+        )
+        return str(result[0]["generated_text"])

--- a/src/nodetool/nodes/huggingface/text2text_generation.py
+++ b/src/nodetool/nodes/huggingface/text2text_generation.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from typing import Any
 
 from nodetool.metadata.types import HuggingFaceModel
-from nodetool.nodes.huggingface.huggingface_pipeline import HuggingFacePipelineNode
+from nodetool.nodes.huggingface.huggingface_pipeline import (
+    HuggingFacePipelineNode,
+    select_inference_dtype,
+)
 from nodetool.workflows.processing_context import ProcessingContext
 
 from pydantic import Field
@@ -123,14 +126,16 @@ class Text2TextGeneration(HuggingFacePipelineNode):
             pipeline_task="text2text-generation",
             model_id=self.get_model_id(),
             device=context.device,
+            torch_dtype=select_inference_dtype(),
         )
 
     async def process(self, context: ProcessingContext) -> str:
         assert self._pipeline is not None
-        result = await self.run_pipeline_in_thread(
-            self.text,
-            max_new_tokens=self.max_new_tokens,
-            temperature=self.temperature if self.do_sample else None,
-            do_sample=self.do_sample,
-        )
+        kwargs: dict = {
+            "max_new_tokens": self.max_new_tokens,
+            "do_sample": self.do_sample,
+        }
+        if self.do_sample:
+            kwargs["temperature"] = self.temperature
+        result = await self.run_pipeline_in_thread(self.text, **kwargs)
         return str(result[0]["generated_text"])

--- a/src/nodetool/nodes/huggingface/text_generation.py
+++ b/src/nodetool/nodes/huggingface/text_generation.py
@@ -147,6 +147,28 @@ class TextGeneration(HuggingFacePipelineNode):
             HFTextGeneration(
                 repo_id="unsloth/Ministral-3-3B-Base-2512-unsloth-bnb-4bit"
             ),
+            # Phi-4 family (Microsoft)
+            HFTextGeneration(repo_id="microsoft/phi-4"),
+            HFTextGeneration(repo_id="microsoft/phi-4-mini-instruct"),
+            HFTextGeneration(repo_id="microsoft/phi-4-reasoning"),
+            HFTextGeneration(repo_id="microsoft/phi-4-reasoning-plus"),
+            HFTextGeneration(repo_id="unsloth/phi-4-bnb-4bit"),
+            HFTextGeneration(repo_id="unsloth/phi-4-mini-instruct-bnb-4bit"),
+            # DeepSeek-R1 reasoning distillations
+            HFTextGeneration(repo_id="deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"),
+            HFTextGeneration(repo_id="deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"),
+            HFTextGeneration(repo_id="deepseek-ai/DeepSeek-R1-Distill-Llama-8B"),
+            HFTextGeneration(repo_id="deepseek-ai/DeepSeek-R1-Distill-Qwen-14B"),
+            HFTextGeneration(repo_id="unsloth/DeepSeek-R1-Distill-Qwen-7B-bnb-4bit"),
+            HFTextGeneration(repo_id="unsloth/DeepSeek-R1-Distill-Llama-8B-bnb-4bit"),
+            # Gemma 3 native (Google)
+            HFTextGeneration(repo_id="google/gemma-3-1b-it"),
+            HFTextGeneration(repo_id="google/gemma-3-4b-it"),
+            HFTextGeneration(repo_id="google/gemma-3-12b-it"),
+            HFTextGeneration(repo_id="google/gemma-3-27b-it"),
+            # Mistral Small 3.1
+            HFTextGeneration(repo_id="mistralai/Mistral-Small-3.1-24B-Instruct-2503"),
+            HFTextGeneration(repo_id="unsloth/Mistral-Small-3.1-24B-Instruct-2503-bnb-4bit"),
         ]
 
     def _provider_model_id(self) -> str:

--- a/src/nodetool/nodes/huggingface/text_to_speech.py
+++ b/src/nodetool/nodes/huggingface/text_to_speech.py
@@ -550,6 +550,26 @@ class TextToSpeech(HuggingFacePipelineNode):
                 repo_id="facebook/mms-tts-deu",
                 allow_patterns=["*.bin", "*.json", "*.txt"],
             ),
+            HFTextToSpeech(
+                repo_id="facebook/mms-tts-jpn",
+                allow_patterns=["*.bin", "*.json", "*.txt"],
+            ),
+            HFTextToSpeech(
+                repo_id="facebook/mms-tts-zho",
+                allow_patterns=["*.bin", "*.json", "*.txt"],
+            ),
+            HFTextToSpeech(
+                repo_id="OuteAI/OuteTTS-0.2-500M",
+                allow_patterns=["*.safetensors", "*.json", "*.txt"],
+            ),
+            HFTextToSpeech(
+                repo_id="OuteAI/OuteTTS-0.3-1B",
+                allow_patterns=["*.safetensors", "*.json", "*.txt"],
+            ),
+            HFTextToSpeech(
+                repo_id="microsoft/speecht5_tts",
+                allow_patterns=["*.safetensors", "*.json", "*.txt"],
+            ),
         ]
 
     def get_model_id(self):

--- a/src/nodetool/nodes/huggingface/text_to_video.py
+++ b/src/nodetool/nodes/huggingface/text_to_video.py
@@ -329,6 +329,14 @@ class Wan_T2V(HuggingFacePipelineNode):
                 repo_id="Wan-AI/Wan2.2-TI2V-5B-Diffusers",
                 allow_patterns=["**/*.safetensors", "**/*.json", "**/*.txt", "*.json"],
             ),
+            HFTextToVideo(
+                repo_id="Wan-AI/Wan2.2-T2V-14B-Diffusers",
+                allow_patterns=["**/*.safetensors", "**/*.json", "**/*.txt", "*.json"],
+            ),
+            HFTextToVideo(
+                repo_id="Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+                allow_patterns=["**/*.safetensors", "**/*.json", "**/*.txt", "*.json"],
+            ),
         ]
 
     @classmethod

--- a/src/nodetool/nodes/huggingface/video_classification.py
+++ b/src/nodetool/nodes/huggingface/video_classification.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from typing import Any
+
+from nodetool.metadata.types import HuggingFaceModel, VideoRef
+from nodetool.nodes.huggingface.huggingface_pipeline import (
+    HuggingFacePipelineNode,
+    select_inference_dtype,
+)
+from nodetool.workflows.processing_context import ProcessingContext
+
+from pydantic import Field
+
+
+class VideoClassifier(HuggingFacePipelineNode):
+    """
+    Classifies video clips into action or scene categories using video transformer models.
+    video, classification, action-recognition, computer-vision, VideoMAE, TimeSformer
+
+    Use cases:
+    - Recognize human actions and activities in surveillance or sports footage
+    - Moderate video content by detecting inappropriate scenes
+    - Tag and organize video libraries by scene type or activity
+    - Enable smart search over large video collections
+    - Analyze movement patterns in sports, healthcare, or robotics
+    """
+
+    model: HuggingFaceModel = Field(
+        default=HuggingFaceModel(repo_id="MCG-NJU/videomae-base-finetuned-kinetics"),
+        title="Model",
+        description="The video classification model. VideoMAE and TimeSformer are strong general-purpose models; task-specific fine-tuned variants are available for sports, cooking, etc.",
+    )
+    video: VideoRef = Field(
+        default=VideoRef(),
+        title="Video",
+        description="The video clip to classify. Shorter clips (2-10s) tend to give better results.",
+    )
+    num_frames: int = Field(
+        default=8,
+        title="Num Frames",
+        description="Number of frames to sample from the video for classification. Higher values capture more temporal detail but use more memory.",
+        ge=4,
+        le=32,
+    )
+
+    _pipeline: Any = None
+
+    @classmethod
+    def get_recommended_models(cls) -> list[HuggingFaceModel]:
+        return [
+            HuggingFaceModel(
+                repo_id="MCG-NJU/videomae-base-finetuned-kinetics",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="MCG-NJU/videomae-large-finetuned-kinetics",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="facebook/timesformer-base-finetuned-k400",
+                allow_patterns=["README.md", "*.bin", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="facebook/timesformer-base-finetuned-k600",
+                allow_patterns=["README.md", "*.bin", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="facebook/timesformer-hr-finetuned-k400",
+                allow_patterns=["README.md", "*.bin", "*.json", "**/*.json"],
+            ),
+            HuggingFaceModel(
+                repo_id="sayakpaul/videomae-base-finetuned-ucf101-subset",
+                allow_patterns=["README.md", "*.safetensors", "*.json", "**/*.json"],
+            ),
+        ]
+
+    def required_inputs(self):
+        return ["video"]
+
+    @classmethod
+    def get_title(cls) -> str:
+        return "Video Classifier"
+
+    def get_model_id(self):
+        return self.model.repo_id
+
+    async def move_to_device(self, device: str):
+        if self._pipeline is not None:
+            self._pipeline.model.to(device)
+
+    async def preload_model(self, context: ProcessingContext):
+        self._pipeline = await self.load_pipeline(
+            context=context,
+            pipeline_task="video-classification",
+            model_id=self.get_model_id(),
+            device=context.device,
+            torch_dtype=select_inference_dtype(),
+        )
+
+    async def process(self, context: ProcessingContext) -> dict[str, float]:
+        assert self._pipeline is not None
+
+        from nodetool.nodes.huggingface.image_text_to_text import extract_video_frames
+
+        video_bytes = await context.asset_to_bytes(self.video)
+        frames = await context.run_worker(
+            extract_video_frames, video_bytes, fps=1
+        )
+
+        # Uniformly sample num_frames from extracted frames
+        if len(frames) > self.num_frames:
+            indices = [
+                int(i * (len(frames) - 1) / (self.num_frames - 1))
+                for i in range(self.num_frames)
+            ]
+            frames = [frames[i] for i in indices]
+
+        result = await self.run_pipeline_in_thread(frames)
+        return {str(item["label"]): float(item["score"]) for item in result}

--- a/tests/test_document_question_answering.py
+++ b/tests/test_document_question_answering.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+if __package__ is None or __package__ == "":
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from nodetool.nodes.huggingface.document_question_answering import DocumentQuestionAnswering
+
+
+def test_document_qa_default_model():
+    node = DocumentQuestionAnswering()
+    assert node.model.repo_id == "impira/layoutlm-document-qa"
+
+
+def test_document_qa_recommended_models():
+    models = DocumentQuestionAnswering.get_recommended_models()
+    assert len(models) > 0
+    repo_ids = [m.repo_id for m in models]
+    assert any("layoutlm" in r for r in repo_ids)
+    assert any("donut" in r for r in repo_ids)
+
+
+def test_document_qa_required_inputs():
+    assert DocumentQuestionAnswering.required_inputs(DocumentQuestionAnswering()) == ["image", "question"]
+
+
+def test_document_qa_title():
+    assert DocumentQuestionAnswering.get_title() == "Document Question Answering"

--- a/tests/test_image_segmentation_mask_generation.py
+++ b/tests/test_image_segmentation_mask_generation.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+if __package__ is None or __package__ == "":
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from nodetool.nodes.huggingface.image_segmentation import MaskGeneration
+
+
+def test_mask_generation_default_model():
+    node = MaskGeneration()
+    assert node.model.repo_id == "facebook/sam2.1-hiera-large"
+
+
+def test_mask_generation_get_model_id():
+    node = MaskGeneration()
+    assert node.get_model_id() == "facebook/sam2.1-hiera-large"
+
+
+def test_mask_generation_recommended_models():
+    models = MaskGeneration.get_recommended_models()
+    assert len(models) > 0
+    repo_ids = [m.repo_id for m in models]
+    assert any("sam2" in r for r in repo_ids)
+    assert any("sam3" in r for r in repo_ids)
+
+
+def test_mask_generation_required_inputs():
+    assert MaskGeneration.required_inputs(MaskGeneration()) == ["image"]
+
+
+def test_mask_generation_title():
+    assert MaskGeneration.get_title() == "Mask Generation (SAM)"
+
+
+def test_mask_generation_defaults():
+    node = MaskGeneration()
+    assert node.points_per_side == 32
+    assert node.pred_iou_thresh == 0.88

--- a/tests/test_image_to_video_wan_flf2v.py
+++ b/tests/test_image_to_video_wan_flf2v.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+if __package__ is None or __package__ == "":
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from nodetool.nodes.huggingface.image_to_video import Wan_FLF2V
+
+
+def test_wan_flf2v_default_model():
+    node = Wan_FLF2V()
+    assert node.model_variant == Wan_FLF2V.WanFLF2VModel.WAN_2_2_FLF2V_14B_720P
+
+
+def test_wan_flf2v_get_model_id():
+    node = Wan_FLF2V()
+    assert node.get_model_id() == "Wan-AI/Wan2.2-FLF2V-14B-720P-Diffusers"
+
+
+def test_wan_flf2v_model_variant_2_1():
+    node = Wan_FLF2V()
+    node.model_variant = Wan_FLF2V.WanFLF2VModel.WAN_2_1_FLF2V_14B_720P
+    assert node.get_model_id() == "Wan-AI/Wan2.1-FLF2V-14B-720P-diffusers"
+
+
+def test_wan_flf2v_recommended_models():
+    models = Wan_FLF2V.get_recommended_models()
+    assert len(models) == 2
+    repo_ids = [m.repo_id for m in models]
+    assert "Wan-AI/Wan2.2-FLF2V-14B-720P-Diffusers" in repo_ids
+    assert "Wan-AI/Wan2.1-FLF2V-14B-720P-diffusers" in repo_ids
+
+
+def test_wan_flf2v_required_inputs():
+    assert Wan_FLF2V.required_inputs(Wan_FLF2V()) == ["first_image", "last_image"]
+
+
+def test_wan_flf2v_title():
+    assert Wan_FLF2V.get_title() == "Wan (First-Last-Frame to Video)"

--- a/tests/test_summarization.py
+++ b/tests/test_summarization.py
@@ -1,13 +1,36 @@
 import sys
 from pathlib import Path
 
-if __package__ is None or __package__ == '':
+if __package__ is None or __package__ == "":
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
     sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from nodetool.dsl.huggingface.summarization import Summarize
-from tests.test_utils import main
+from nodetool.nodes.huggingface.summarization import Summarization
 
 
-if __name__ == '__main__':
-    main([Summarize()])
+def test_summarization_default_model():
+    node = Summarization()
+    assert node.model.repo_id == "facebook/bart-large-cnn"
+
+
+def test_summarization_recommended_models():
+    models = Summarization.get_recommended_models()
+    assert len(models) > 0
+    repo_ids = [m.repo_id for m in models]
+    assert any("bart" in r for r in repo_ids)
+    assert any("pegasus" in r for r in repo_ids)
+
+
+def test_summarization_required_inputs():
+    assert Summarization.required_inputs(Summarization()) == ["text"]
+
+
+def test_summarization_title():
+    assert Summarization.get_title() == "Summarization"
+
+
+def test_summarization_defaults():
+    node = Summarization()
+    assert node.max_length == 130
+    assert node.min_length == 30
+    assert node.do_sample is False

--- a/tests/test_text2text_generation.py
+++ b/tests/test_text2text_generation.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+if __package__ is None or __package__ == "":
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from nodetool.nodes.huggingface.text2text_generation import Text2TextGeneration
+
+
+def test_text2text_default_model():
+    node = Text2TextGeneration()
+    assert node.model.repo_id == "google/flan-t5-base"
+
+
+def test_text2text_recommended_models():
+    models = Text2TextGeneration.get_recommended_models()
+    assert len(models) > 0
+    repo_ids = [m.repo_id for m in models]
+    assert any("flan-t5" in r for r in repo_ids)
+    assert any("mt5" in r for r in repo_ids)
+
+
+def test_text2text_required_inputs():
+    assert Text2TextGeneration.required_inputs(Text2TextGeneration()) == ["text"]
+
+
+def test_text2text_title():
+    assert Text2TextGeneration.get_title() == "Text-to-Text Generation"
+
+
+def test_text2text_defaults():
+    node = Text2TextGeneration()
+    assert node.max_new_tokens == 200
+    assert node.do_sample is False
+    assert node.temperature == 1.0

--- a/tests/test_video_classification.py
+++ b/tests/test_video_classification.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+if __package__ is None or __package__ == "":
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from nodetool.nodes.huggingface.video_classification import VideoClassifier
+
+
+def test_video_classifier_default_model():
+    node = VideoClassifier()
+    assert node.model.repo_id == "MCG-NJU/videomae-base-finetuned-kinetics"
+
+
+def test_video_classifier_recommended_models():
+    models = VideoClassifier.get_recommended_models()
+    assert len(models) > 0
+    repo_ids = [m.repo_id for m in models]
+    assert any("videomae" in r for r in repo_ids)
+    assert any("timesformer" in r for r in repo_ids)
+
+
+def test_video_classifier_required_inputs():
+    assert VideoClassifier.required_inputs(VideoClassifier()) == ["video"]
+
+
+def test_video_classifier_title():
+    assert VideoClassifier.get_title() == "Video Classifier"


### PR DESCRIPTION
New pipeline nodes:
- video_classification.py: VideoClassifier using pipeline("video-classification")
  with VideoMAE (MCG-NJU) and TimeSformer (Facebook) models
- summarization.py: Summarization using pipeline("summarization")
  with BART-large-CNN/XSUM, DistilBART, PEGASUS, T5 models
- text2text_generation.py: Text2TextGeneration using pipeline("text2text-generation")
  with FLAN-T5 (small/base/large/xl/xxl), mT5, CodeT5+ models
- document_question_answering.py: DocumentQuestionAnswering using
  pipeline("document-question-answering") with LayoutLM, Donut models

New nodes in existing files:
- image_segmentation.py: MaskGeneration node using pipeline("mask-generation")
  with SAM/SAM2.1/SAM3; also added SAM3 to SAM2Segmentation recommended models
- image_to_video.py: Wan_FLF2V node for first-last-frame-to-video generation
  using Wan2.2-FLF2V-14B-720P and Wan2.1-FLF2V-14B-720P

Model additions to existing nodes:
- text_generation.py: Phi-4 family, DeepSeek-R1 distillations, Gemma 3 native,
  Mistral Small 3.1 (with Unsloth 4-bit variants)
- depth_estimation.py: Apple DepthPro-hf, Depth-Anything-V2 metric variants
- text_to_video.py: Wan2.2-T2V-14B, Wan2.1-T2V-1.3B models
- image_segmentation.py: SAM2.1-hiera-large/base-plus, SAM3
- text_to_speech.py: OuteTTS-0.2-500M, OuteTTS-0.3-1B, SpeechT5,
  MMS-TTS Japanese/Chinese
- image_text_to_text.py: Florence-2 base/large/ft, Phi-4-multimodal,
  SmolVLM2, InternVL2.5, Idefics3

https://claude.ai/code/session_01ATHL331D4N26F8L1QYf6Fr