### PR TITLE
Add ACE-Step 1.5 text-to-audio nodes with multiple task modes

### DIFF
--- a/src/nodetool/nodes/huggingface/text_to_audio.py
+++ b/src/nodetool/nodes/huggingface/text_to_audio.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -11,7 +12,10 @@ from nodetool.metadata.types import (
     HFTextToAudio,
     HuggingFaceModel,
 )
-from nodetool.nodes.huggingface.huggingface_pipeline import HuggingFacePipelineNode
+from nodetool.nodes.huggingface.huggingface_pipeline import (
+    HuggingFacePipelineNode,
+    select_inference_dtype,
+)
 from nodetool.workflows.processing_context import ProcessingContext
 from nodetool.workflows.memory_utils import run_gc
 from nodetool.workflows.types import NodeProgress
@@ -26,6 +30,7 @@ if TYPE_CHECKING:
     from diffusers.pipelines.stable_audio.pipeline_stable_audio import (
         StableAudioPipeline,
     )
+    from diffusers.pipelines.ace_step.pipeline_ace_step import AceStepPipeline
     from transformers import AutoProcessor, MusicgenForConditionalGeneration
     from transformers import AutoTokenizer
     from transformers import AutoFeatureExtractor, set_seed
@@ -614,6 +619,180 @@ class StableAudioNode(HuggingFacePipelineNode):
         run_gc("After StableAudio inference", log_before_after=False)
         audio = await context.audio_from_numpy(output, sampling_rate)
         return audio
+
+
+class AceStepVariant(Enum):
+    TURBO = "turbo"
+    BASE = "base"
+    SFT = "sft"
+
+
+# Maps each variant to its DiT checkpoint on the HuggingFace Hub.
+_ACE_STEP_REPOS: dict[AceStepVariant, str] = {
+    AceStepVariant.TURBO: "ACE-Step/Ace-Step1.5",
+    AceStepVariant.BASE: "ACE-Step/acestep-v15-base",
+    AceStepVariant.SFT: "ACE-Step/acestep-v15-sft",
+}
+
+
+class AceStep(HuggingFacePipelineNode):
+    """
+    Generates commercial-grade stereo music with lyrics using ACE-Step 1.5.
+    audio, music, generation, text-to-music, lyrics, stereo, ace-step, song
+
+    Use cases:
+    - Generate full songs with vocals from a style prompt and structured lyrics
+    - Produce 48 kHz stereo music in 50+ languages
+    - Create instrumental tracks, background music, and soundtracks
+    - Fast 8-step generation with the guidance-distilled turbo checkpoint
+    """
+
+    variant: AceStepVariant = Field(
+        default=AceStepVariant.TURBO,
+        title="Variant",
+        description=(
+            "DiT checkpoint to use. 'turbo' is guidance-distilled (8 steps, CFG "
+            "ignored); 'base' and 'sft' use classifier-free guidance and benefit "
+            "from more steps (30-60) for higher quality."
+        ),
+    )
+    prompt: str = Field(
+        default="A beautiful piano piece with soft melodies and gentle rhythm",
+        title="Prompt",
+        description=(
+            "Describe the music style, instruments, mood, and tempo "
+            "(e.g., 'upbeat pop song with electric guitar and drums')."
+        ),
+    )
+    lyrics: str = Field(
+        default="[verse]\nSoft notes in the morning light\nDancing through the air so bright\n[chorus]\nMusic fills the air tonight\nEvery note feels just right",
+        title="Lyrics",
+        description=(
+            "Lyrics for the song. Structure with tags like [verse], [chorus], "
+            "[bridge]. Leave empty for instrumental music."
+        ),
+    )
+    audio_duration: float = Field(
+        default=60.0,
+        title="Audio Duration",
+        description="Duration of the generated music in seconds (10 to 600).",
+        ge=10.0,
+        le=600.0,
+    )
+    vocal_language: str = Field(
+        default="en",
+        title="Vocal Language",
+        description="Language code for the lyrics (e.g., 'en', 'zh', 'ja', 'ko', 'fr', 'de', 'es').",
+    )
+    num_inference_steps: int = Field(
+        default=8,
+        title="Num Inference Steps",
+        description="Denoising steps. Turbo is tuned for 8; use 30-60 on base/sft for higher quality.",
+        ge=1,
+        le=200,
+    )
+    guidance_scale: float = Field(
+        default=7.0,
+        title="Guidance Scale",
+        description="Classifier-free guidance scale for base/sft. Ignored for the turbo variant.",
+        ge=1.0,
+        le=15.0,
+    )
+    shift: float = Field(
+        default=3.0,
+        title="Shift",
+        description="Shift parameter for the flow-matching timestep schedule (1.0, 2.0, or 3.0).",
+        ge=1.0,
+        le=3.0,
+    )
+    seed: int = Field(
+        default=-1,
+        title="Seed",
+        description="Random seed for reproducible generation. Use -1 for random.",
+        ge=-1,
+    )
+
+    _pipeline: Any = None
+
+    @classmethod
+    def get_title(cls) -> str:
+        return "ACE-Step 1.5"
+
+    @classmethod
+    def get_basic_fields(cls) -> list[str]:
+        return ["variant", "prompt", "lyrics", "audio_duration"]
+
+    @classmethod
+    def get_recommended_models(cls) -> list[HuggingFaceModel]:
+        return [
+            HFTextToAudio(
+                repo_id=repo_id,
+                allow_patterns=["*.safetensors", "*.json", "*.txt", "*.model"],
+            )
+            for repo_id in _ACE_STEP_REPOS.values()
+        ]
+
+    def get_model_id(self) -> str:
+        return _ACE_STEP_REPOS[self.variant]
+
+    async def preload_model(self, context: ProcessingContext):
+        from diffusers.pipelines.ace_step.pipeline_ace_step import AceStepPipeline
+
+        self._pipeline = await self.load_model(
+            context=context,
+            model_class=AceStepPipeline,
+            model_id=self.get_model_id(),
+            torch_dtype=select_inference_dtype(),
+            variant=None,
+        )
+
+    async def process(self, context: ProcessingContext) -> AudioRef:
+        if self._pipeline is None:
+            raise ValueError("Pipeline not initialized")
+
+        import torch
+
+        generator = torch.Generator(device="cpu")
+        if self.seed != -1:
+            generator = generator.manual_seed(self.seed)
+
+        # Turbo is guidance-distilled: CFG is baked into the weights, so a scale
+        # above 1.0 is ignored by the pipeline. Pass 1.0 to skip the warning.
+        guidance_scale = (
+            1.0 if self.variant == AceStepVariant.TURBO else self.guidance_scale
+        )
+
+        def progress_callback(
+            step: int, timestep: int, latents: "torch.FloatTensor"
+        ) -> None:
+            context.post_message(
+                NodeProgress(
+                    node_id=self.id,
+                    progress=step,
+                    total=self.num_inference_steps,
+                )
+            )
+
+        result = await self.run_pipeline_in_thread(
+            prompt=self.prompt,
+            lyrics=self.lyrics,
+            audio_duration=self.audio_duration,
+            vocal_language=self.vocal_language,
+            num_inference_steps=self.num_inference_steps,
+            guidance_scale=guidance_scale,
+            shift=self.shift,
+            generator=generator,
+            callback=progress_callback,
+            callback_steps=1,
+        )
+
+        # audios[0] is a stereo tensor of shape [channels, samples]; transpose to
+        # [samples, channels] for audio_from_numpy.
+        audio = result.audios[0]
+        output = audio.T.float().cpu().numpy()
+        sampling_rate = self._pipeline.sample_rate
+        run_gc("After ACE-Step inference", log_before_after=False)
+        return await context.audio_from_numpy(output, sampling_rate)
 
 
 # class ParlerTTSNode(HuggingFacePipelineNode):

--- a/src/nodetool/nodes/huggingface/text_to_audio.py
+++ b/src/nodetool/nodes/huggingface/text_to_audio.py
@@ -635,16 +635,14 @@ _ACE_STEP_REPOS: dict[AceStepVariant, str] = {
 }
 
 
-class AceStep(HuggingFacePipelineNode):
+class AceStepBaseNode(HuggingFacePipelineNode):
     """
-    Generates commercial-grade stereo music with lyrics using ACE-Step 1.5.
-    audio, music, generation, text-to-music, lyrics, stereo, ace-step, song
+    Shared base for the ACE-Step 1.5 task nodes.
 
-    Use cases:
-    - Generate full songs with vocals from a style prompt and structured lyrics
-    - Produce 48 kHz stereo music in 50+ languages
-    - Create instrumental tracks, background music, and soundtracks
-    - Fast 8-step generation with the guidance-distilled turbo checkpoint
+    Holds the conditioning fields (prompt, lyrics, language), the sampling
+    controls (steps, guidance, shift, seed), checkpoint loading, and the audio
+    helpers. Concrete task nodes add their task-specific inputs and call
+    ``_run`` with the matching ``task_type``.
     """
 
     variant: AceStepVariant = Field(
@@ -665,19 +663,12 @@ class AceStep(HuggingFacePipelineNode):
         ),
     )
     lyrics: str = Field(
-        default="[verse]\nSoft notes in the morning light\nDancing through the air so bright\n[chorus]\nMusic fills the air tonight\nEvery note feels just right",
+        default="",
         title="Lyrics",
         description=(
             "Lyrics for the song. Structure with tags like [verse], [chorus], "
             "[bridge]. Leave empty for instrumental music."
         ),
-    )
-    audio_duration: float = Field(
-        default=60.0,
-        title="Audio Duration",
-        description="Duration of the generated music in seconds (10 to 600).",
-        ge=10.0,
-        le=600.0,
     )
     vocal_language: str = Field(
         default="en",
@@ -715,12 +706,8 @@ class AceStep(HuggingFacePipelineNode):
     _pipeline: Any = None
 
     @classmethod
-    def get_title(cls) -> str:
-        return "ACE-Step 1.5"
-
-    @classmethod
-    def get_basic_fields(cls) -> list[str]:
-        return ["variant", "prompt", "lyrics", "audio_duration"]
+    def is_visible(cls) -> bool:
+        return cls is not AceStepBaseNode
 
     @classmethod
     def get_recommended_models(cls) -> list[HuggingFaceModel]:
@@ -746,7 +733,35 @@ class AceStep(HuggingFacePipelineNode):
             variant=None,
         )
 
-    async def process(self, context: ProcessingContext) -> AudioRef:
+    def _resolved_guidance_scale(self) -> float:
+        # Turbo is guidance-distilled: CFG is baked into the weights, so a scale
+        # above 1.0 is ignored by the pipeline. Pass 1.0 to skip the warning.
+        if self.variant == AceStepVariant.TURBO:
+            return 1.0
+        return self.guidance_scale
+
+    async def _audio_to_tensor(
+        self, context: ProcessingContext, audio: AudioRef
+    ) -> "torch.Tensor":
+        """Decode an AudioRef into a stereo ``[channels, samples]`` tensor at the
+        pipeline sample rate (48 kHz for the released checkpoints)."""
+        import torch
+
+        sample_rate = self._pipeline.sample_rate
+        samples, _, _ = await context.audio_to_numpy(audio, sample_rate=sample_rate)
+        tensor = torch.from_numpy(samples).float()
+        if tensor.ndim == 1:
+            tensor = tensor.unsqueeze(0)
+        # ACE-Step expects stereo input; duplicate a mono channel.
+        if tensor.shape[0] == 1:
+            tensor = tensor.repeat(2, 1)
+        return tensor
+
+    async def _run(
+        self, context: ProcessingContext, *, task_type: str, **task_kwargs: Any
+    ) -> AudioRef:
+        """Run the pipeline with the shared conditioning plus task-specific
+        keyword arguments and return the generated stereo audio."""
         if self._pipeline is None:
             raise ValueError("Pipeline not initialized")
 
@@ -755,12 +770,6 @@ class AceStep(HuggingFacePipelineNode):
         generator = torch.Generator(device="cpu")
         if self.seed != -1:
             generator = generator.manual_seed(self.seed)
-
-        # Turbo is guidance-distilled: CFG is baked into the weights, so a scale
-        # above 1.0 is ignored by the pipeline. Pass 1.0 to skip the warning.
-        guidance_scale = (
-            1.0 if self.variant == AceStepVariant.TURBO else self.guidance_scale
-        )
 
         def progress_callback(
             step: int, timestep: int, latents: "torch.FloatTensor"
@@ -776,14 +785,15 @@ class AceStep(HuggingFacePipelineNode):
         result = await self.run_pipeline_in_thread(
             prompt=self.prompt,
             lyrics=self.lyrics,
-            audio_duration=self.audio_duration,
             vocal_language=self.vocal_language,
             num_inference_steps=self.num_inference_steps,
-            guidance_scale=guidance_scale,
+            guidance_scale=self._resolved_guidance_scale(),
             shift=self.shift,
+            task_type=task_type,
             generator=generator,
             callback=progress_callback,
             callback_steps=1,
+            **task_kwargs,
         )
 
         # audios[0] is a stereo tensor of shape [channels, samples]; transpose to
@@ -791,8 +801,298 @@ class AceStep(HuggingFacePipelineNode):
         audio = result.audios[0]
         output = audio.T.float().cpu().numpy()
         sampling_rate = self._pipeline.sample_rate
-        run_gc("After ACE-Step inference", log_before_after=False)
+        run_gc(f"After ACE-Step {task_type} inference", log_before_after=False)
         return await context.audio_from_numpy(output, sampling_rate)
+
+
+class AceStep(AceStepBaseNode):
+    """
+    Generates commercial-grade stereo music with lyrics using ACE-Step 1.5.
+    audio, music, generation, text-to-music, lyrics, stereo, ace-step, song
+
+    Use cases:
+    - Generate full songs with vocals from a style prompt and structured lyrics
+    - Produce 48 kHz stereo music in 50+ languages
+    - Create instrumental tracks, background music, and soundtracks
+    - Fast 8-step generation with the guidance-distilled turbo checkpoint
+    """
+
+    lyrics: str = Field(
+        default="[verse]\nSoft notes in the morning light\nDancing through the air so bright\n[chorus]\nMusic fills the air tonight\nEvery note feels just right",
+        title="Lyrics",
+        description=(
+            "Lyrics for the song. Structure with tags like [verse], [chorus], "
+            "[bridge]. Leave empty for instrumental music."
+        ),
+    )
+    audio_duration: float = Field(
+        default=60.0,
+        title="Audio Duration",
+        description="Duration of the generated music in seconds (10 to 600).",
+        ge=10.0,
+        le=600.0,
+    )
+
+    @classmethod
+    def get_title(cls) -> str:
+        return "ACE-Step 1.5"
+
+    @classmethod
+    def get_basic_fields(cls) -> list[str]:
+        return ["variant", "prompt", "lyrics", "audio_duration"]
+
+    async def process(self, context: ProcessingContext) -> AudioRef:
+        return await self._run(
+            context,
+            task_type="text2music",
+            audio_duration=self.audio_duration,
+        )
+
+
+class AceStepCover(AceStepBaseNode):
+    """
+    Re-records source audio in a new timbre using ACE-Step 1.5 cover mode.
+    audio, music, cover, timbre-transfer, voice-conversion, ace-step
+
+    Use cases:
+    - Re-sing an existing song with a different voice or instrument timbre
+    - Transfer the style of a reference recording onto source audio
+    - Create covers that keep the melody but change the sound
+    """
+
+    src_audio: AudioRef = Field(
+        default=AudioRef(),
+        title="Source Audio",
+        description="Source audio (stereo, 48 kHz) providing the musical content to cover.",
+    )
+    reference_audio: AudioRef = Field(
+        default=AudioRef(),
+        title="Reference Audio",
+        description="Reference audio whose timbre/style is transferred onto the source.",
+    )
+    audio_cover_strength: float = Field(
+        default=1.0,
+        title="Cover Strength",
+        description="Strength of the cover blending (0.0 keeps the source, 1.0 fully re-records).",
+        ge=0.0,
+        le=1.0,
+    )
+
+    @classmethod
+    def get_title(cls) -> str:
+        return "ACE-Step Cover"
+
+    @classmethod
+    def get_basic_fields(cls) -> list[str]:
+        return ["variant", "src_audio", "reference_audio", "audio_cover_strength"]
+
+    def required_inputs(self):
+        return ["src_audio", "reference_audio"]
+
+    async def process(self, context: ProcessingContext) -> AudioRef:
+        src = await self._audio_to_tensor(context, self.src_audio)
+        reference = await self._audio_to_tensor(context, self.reference_audio)
+        return await self._run(
+            context,
+            task_type="cover",
+            src_audio=src,
+            reference_audio=reference,
+            audio_cover_strength=self.audio_cover_strength,
+        )
+
+
+class AceStepRepaint(AceStepBaseNode):
+    """
+    Regenerates a section of existing audio while keeping the rest with ACE-Step 1.5.
+    audio, music, repaint, inpainting, edit, ace-step
+
+    Use cases:
+    - Replace a verse or chorus while preserving the surrounding song
+    - Fix or rework a specific time range of a track
+    - Generate variations of one section without re-rendering the whole piece
+    """
+
+    src_audio: AudioRef = Field(
+        default=AudioRef(),
+        title="Source Audio",
+        description="Audio (stereo, 48 kHz) to repaint. The region outside the range is kept.",
+    )
+    repainting_start: float = Field(
+        default=0.0,
+        title="Repaint Start",
+        description="Start time in seconds of the region to regenerate.",
+        ge=0.0,
+    )
+    repainting_end: float = Field(
+        default=-1.0,
+        title="Repaint End",
+        description="End time in seconds of the region to regenerate. Use -1 for until the end.",
+        ge=-1.0,
+    )
+
+    @classmethod
+    def get_title(cls) -> str:
+        return "ACE-Step Repaint"
+
+    @classmethod
+    def get_basic_fields(cls) -> list[str]:
+        return ["src_audio", "repainting_start", "repainting_end", "prompt"]
+
+    def required_inputs(self):
+        return ["src_audio"]
+
+    async def process(self, context: ProcessingContext) -> AudioRef:
+        src = await self._audio_to_tensor(context, self.src_audio)
+        return await self._run(
+            context,
+            task_type="repaint",
+            src_audio=src,
+            repainting_start=self.repainting_start,
+            repainting_end=self.repainting_end,
+        )
+
+
+class AceStepExtract(AceStepBaseNode):
+    """
+    Extracts a single track (e.g. vocals, drums) from audio with ACE-Step 1.5.
+    audio, music, extract, stem-separation, vocals, drums, ace-step
+
+    Use cases:
+    - Isolate vocals, drums, bass, or other stems from a mix
+    - Build acapellas or instrumentals from a full track
+    - Prepare stems for remixing and sampling
+    """
+
+    src_audio: AudioRef = Field(
+        default=AudioRef(),
+        title="Source Audio",
+        description="Audio (stereo, 48 kHz) to extract a track from.",
+    )
+    track_name: str = Field(
+        default="vocals",
+        title="Track Name",
+        description="Track to extract (e.g. 'vocals', 'drums', 'bass', 'guitar', 'piano').",
+    )
+
+    @classmethod
+    def get_title(cls) -> str:
+        return "ACE-Step Extract"
+
+    @classmethod
+    def get_basic_fields(cls) -> list[str]:
+        return ["src_audio", "track_name"]
+
+    def required_inputs(self):
+        return ["src_audio"]
+
+    async def process(self, context: ProcessingContext) -> AudioRef:
+        src = await self._audio_to_tensor(context, self.src_audio)
+        return await self._run(
+            context,
+            task_type="extract",
+            src_audio=src,
+            track_name=self.track_name,
+        )
+
+
+class AceStepLego(AceStepBaseNode):
+    """
+    Generates a specific track conditioned on existing audio with ACE-Step 1.5 lego mode.
+    audio, music, lego, accompaniment, stem-generation, ace-step
+
+    Use cases:
+    - Add a new instrument track that fits an existing arrangement
+    - Generate a drum or bass line for a given musical context
+    - Regenerate a single track within a chosen time range
+    """
+
+    src_audio: AudioRef = Field(
+        default=AudioRef(),
+        title="Source Audio",
+        description="Audio (stereo, 48 kHz) providing the musical context.",
+    )
+    track_name: str = Field(
+        default="drums",
+        title="Track Name",
+        description="Track to generate (e.g. 'vocals', 'drums', 'bass', 'guitar', 'piano').",
+    )
+    repainting_start: float = Field(
+        default=0.0,
+        title="Region Start",
+        description="Start time in seconds of the region to generate.",
+        ge=0.0,
+    )
+    repainting_end: float = Field(
+        default=-1.0,
+        title="Region End",
+        description="End time in seconds of the region to generate. Use -1 for until the end.",
+        ge=-1.0,
+    )
+
+    @classmethod
+    def get_title(cls) -> str:
+        return "ACE-Step Lego"
+
+    @classmethod
+    def get_basic_fields(cls) -> list[str]:
+        return ["src_audio", "track_name", "repainting_start", "repainting_end"]
+
+    def required_inputs(self):
+        return ["src_audio"]
+
+    async def process(self, context: ProcessingContext) -> AudioRef:
+        src = await self._audio_to_tensor(context, self.src_audio)
+        return await self._run(
+            context,
+            task_type="lego",
+            src_audio=src,
+            track_name=self.track_name,
+            repainting_start=self.repainting_start,
+            repainting_end=self.repainting_end,
+        )
+
+
+class AceStepComplete(AceStepBaseNode):
+    """
+    Completes input audio with additional tracks using ACE-Step 1.5.
+    audio, music, complete, arrangement, accompaniment, ace-step
+
+    Use cases:
+    - Flesh out a sparse demo with extra instrument tracks
+    - Add accompaniment around a lead vocal or melody
+    - Turn a single stem into a fuller arrangement
+    """
+
+    src_audio: AudioRef = Field(
+        default=AudioRef(),
+        title="Source Audio",
+        description="Audio (stereo, 48 kHz) to complete with additional tracks.",
+    )
+    complete_track_classes: list[str] = Field(
+        default_factory=list,
+        title="Track Classes",
+        description="Track classes to add (e.g. ['drums', 'bass', 'guitar']). Empty lets the model decide.",
+    )
+
+    @classmethod
+    def get_title(cls) -> str:
+        return "ACE-Step Complete"
+
+    @classmethod
+    def get_basic_fields(cls) -> list[str]:
+        return ["src_audio", "complete_track_classes", "prompt"]
+
+    def required_inputs(self):
+        return ["src_audio"]
+
+    async def process(self, context: ProcessingContext) -> AudioRef:
+        src = await self._audio_to_tensor(context, self.src_audio)
+        return await self._run(
+            context,
+            task_type="complete",
+            src_audio=src,
+            complete_track_classes=self.complete_track_classes or None,
+        )
 
 
 # class ParlerTTSNode(HuggingFacePipelineNode):

--- a/src/nodetool/nodes/huggingface/text_to_audio.py
+++ b/src/nodetool/nodes/huggingface/text_to_audio.py
@@ -745,6 +745,9 @@ class AceStepBaseNode(HuggingFacePipelineNode):
     ) -> "torch.Tensor":
         """Decode an AudioRef into a stereo ``[channels, samples]`` tensor at the
         pipeline sample rate (48 kHz for the released checkpoints)."""
+        if self._pipeline is None:
+            raise ValueError("Pipeline not initialized")
+
         import torch
 
         sample_rate = self._pipeline.sample_rate

--- a/src/nodetool/nodes/huggingface/text_to_image.py
+++ b/src/nodetool/nodes/huggingface/text_to_image.py
@@ -2439,6 +2439,8 @@ class Kandinsky5Image(HuggingFacePipelineNode):
             or getattr(output, "image", None)
             or getattr(output, "frames", None)
         )
+        if images is None:
+            raise ValueError("Kandinsky pipeline returned no images")
         image = images[0]
         if isinstance(image, (list, tuple)):
             image = image[0]

--- a/src/nodetool/package_metadata/nodetool-huggingface.json
+++ b/src/nodetool/package_metadata/nodetool-huggingface.json
@@ -13389,6 +13389,58 @@
           }
         },
         {
+          "default": "en",
+          "description": "Language code for the lyrics (e.g., 'en', 'zh', 'ja', 'ko', 'fr', 'de', 'es').",
+          "name": "vocal_language",
+          "title": "Vocal Language",
+          "type": {
+            "type": "str"
+          }
+        },
+        {
+          "default": 8,
+          "description": "Denoising steps. Turbo is tuned for 8; use 30-60 on base/sft for higher quality.",
+          "max": 200.0,
+          "min": 1.0,
+          "name": "num_inference_steps",
+          "title": "Num Inference Steps",
+          "type": {
+            "type": "int"
+          }
+        },
+        {
+          "default": 7.0,
+          "description": "Classifier-free guidance scale for base/sft. Ignored for the turbo variant.",
+          "max": 15.0,
+          "min": 1.0,
+          "name": "guidance_scale",
+          "title": "Guidance Scale",
+          "type": {
+            "type": "float"
+          }
+        },
+        {
+          "default": 3.0,
+          "description": "Shift parameter for the flow-matching timestep schedule (1.0, 2.0, or 3.0).",
+          "max": 3.0,
+          "min": 1.0,
+          "name": "shift",
+          "title": "Shift",
+          "type": {
+            "type": "float"
+          }
+        },
+        {
+          "default": -1,
+          "description": "Random seed for reproducible generation. Use -1 for random.",
+          "min": -1.0,
+          "name": "seed",
+          "title": "Seed",
+          "type": {
+            "type": "int"
+          }
+        },
+        {
           "default": 60.0,
           "description": "Duration of the generated music in seconds (10 to 600).",
           "max": 600.0,
@@ -13397,6 +13449,105 @@
           "title": "Audio Duration",
           "type": {
             "type": "float"
+          }
+        }
+      ],
+      "recommended_models": [
+        {
+          "allow_patterns": [
+            "*.safetensors",
+            "*.json",
+            "*.txt",
+            "*.model"
+          ],
+          "id": "ACE-Step/Ace-Step1.5",
+          "name": "ACE-Step/Ace-Step1.5",
+          "repo_id": "ACE-Step/Ace-Step1.5",
+          "type": "hf.text_to_audio"
+        },
+        {
+          "allow_patterns": [
+            "*.safetensors",
+            "*.json",
+            "*.txt",
+            "*.model"
+          ],
+          "id": "ACE-Step/acestep-v15-base",
+          "name": "ACE-Step/acestep-v15-base",
+          "repo_id": "ACE-Step/acestep-v15-base",
+          "type": "hf.text_to_audio"
+        },
+        {
+          "allow_patterns": [
+            "*.safetensors",
+            "*.json",
+            "*.txt",
+            "*.model"
+          ],
+          "id": "ACE-Step/acestep-v15-sft",
+          "name": "ACE-Step/acestep-v15-sft",
+          "repo_id": "ACE-Step/acestep-v15-sft",
+          "type": "hf.text_to_audio"
+        }
+      ],
+      "title": "ACE-Step 1.5"
+    },
+    {
+      "basic_fields": [
+        "variant",
+        "src_audio",
+        "reference_audio",
+        "audio_cover_strength"
+      ],
+      "input_fields": [
+        "prompt",
+        "src_audio",
+        "reference_audio"
+      ],
+      "description": "Re-records source audio in a new timbre using ACE-Step 1.5 cover mode.\n    audio, music, cover, timbre-transfer, voice-conversion, ace-step\n\n    Use cases:\n    - Re-sing an existing song with a different voice or instrument timbre\n    - Transfer the style of a reference recording onto source audio\n    - Create covers that keep the melody but change the sound",
+      "namespace": "huggingface.text_to_audio",
+      "node_type": "huggingface.text_to_audio.AceStepCover",
+      "body": "content_card",
+      "outputs": [
+        {
+          "name": "output",
+          "type": {
+            "type": "audio"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "default": "turbo",
+          "description": "DiT checkpoint to use. 'turbo' is guidance-distilled (8 steps, CFG ignored); 'base' and 'sft' use classifier-free guidance and benefit from more steps (30-60) for higher quality.",
+          "name": "variant",
+          "title": "Variant",
+          "type": {
+            "type": "enum",
+            "type_name": "nodetool.nodes.huggingface.text_to_audio.AceStepVariant",
+            "values": [
+              "turbo",
+              "base",
+              "sft"
+            ]
+          }
+        },
+        {
+          "default": "A beautiful piano piece with soft melodies and gentle rhythm",
+          "description": "Describe the music style, instruments, mood, and tempo (e.g., 'upbeat pop song with electric guitar and drums').",
+          "name": "prompt",
+          "title": "Prompt",
+          "type": {
+            "type": "str"
+          }
+        },
+        {
+          "default": "",
+          "description": "Lyrics for the song. Structure with tags like [verse], [chorus], [bridge]. Leave empty for instrumental music.",
+          "name": "lyrics",
+          "title": "Lyrics",
+          "type": {
+            "type": "str"
           }
         },
         {
@@ -13450,6 +13601,47 @@
           "type": {
             "type": "int"
           }
+        },
+        {
+          "default": {
+            "asset_id": null,
+            "data": null,
+            "metadata": null,
+            "type": "audio",
+            "uri": ""
+          },
+          "description": "Source audio (stereo, 48 kHz) providing the musical content to cover.",
+          "name": "src_audio",
+          "title": "Source Audio",
+          "type": {
+            "type": "audio"
+          }
+        },
+        {
+          "default": {
+            "asset_id": null,
+            "data": null,
+            "metadata": null,
+            "type": "audio",
+            "uri": ""
+          },
+          "description": "Reference audio whose timbre/style is transferred onto the source.",
+          "name": "reference_audio",
+          "title": "Reference Audio",
+          "type": {
+            "type": "audio"
+          }
+        },
+        {
+          "default": 1.0,
+          "description": "Strength of the cover blending (0.0 keeps the source, 1.0 fully re-records).",
+          "max": 1.0,
+          "min": 0.0,
+          "name": "audio_cover_strength",
+          "title": "Cover Strength",
+          "type": {
+            "type": "float"
+          }
         }
       ],
       "recommended_models": [
@@ -13490,7 +13682,736 @@
           "type": "hf.text_to_audio"
         }
       ],
-      "title": "ACE-Step 1.5"
+      "title": "ACE-Step Cover"
+    },
+    {
+      "basic_fields": [
+        "src_audio",
+        "repainting_start",
+        "repainting_end",
+        "prompt"
+      ],
+      "input_fields": [
+        "prompt",
+        "src_audio"
+      ],
+      "description": "Regenerates a section of existing audio while keeping the rest with ACE-Step 1.5.\n    audio, music, repaint, inpainting, edit, ace-step\n\n    Use cases:\n    - Replace a verse or chorus while preserving the surrounding song\n    - Fix or rework a specific time range of a track\n    - Generate variations of one section without re-rendering the whole piece",
+      "namespace": "huggingface.text_to_audio",
+      "node_type": "huggingface.text_to_audio.AceStepRepaint",
+      "body": "content_card",
+      "outputs": [
+        {
+          "name": "output",
+          "type": {
+            "type": "audio"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "default": "turbo",
+          "description": "DiT checkpoint to use. 'turbo' is guidance-distilled (8 steps, CFG ignored); 'base' and 'sft' use classifier-free guidance and benefit from more steps (30-60) for higher quality.",
+          "name": "variant",
+          "title": "Variant",
+          "type": {
+            "type": "enum",
+            "type_name": "nodetool.nodes.huggingface.text_to_audio.AceStepVariant",
+            "values": [
+              "turbo",
+              "base",
+              "sft"
+            ]
+          }
+        },
+        {
+          "default": "A beautiful piano piece with soft melodies and gentle rhythm",
+          "description": "Describe the music style, instruments, mood, and tempo (e.g., 'upbeat pop song with electric guitar and drums').",
+          "name": "prompt",
+          "title": "Prompt",
+          "type": {
+            "type": "str"
+          }
+        },
+        {
+          "default": "",
+          "description": "Lyrics for the song. Structure with tags like [verse], [chorus], [bridge]. Leave empty for instrumental music.",
+          "name": "lyrics",
+          "title": "Lyrics",
+          "type": {
+            "type": "str"
+          }
+        },
+        {
+          "default": "en",
+          "description": "Language code for the lyrics (e.g., 'en', 'zh', 'ja', 'ko', 'fr', 'de', 'es').",
+          "name": "vocal_language",
+          "title": "Vocal Language",
+          "type": {
+            "type": "str"
+          }
+        },
+        {
+          "default": 8,
+          "description": "Denoising steps. Turbo is tuned for 8; use 30-60 on base/sft for higher quality.",
+          "max": 200.0,
+          "min": 1.0,
+          "name": "num_inference_steps",
+          "title": "Num Inference Steps",
+          "type": {
+            "type": "int"
+          }
+        },
+        {
+          "default": 7.0,
+          "description": "Classifier-free guidance scale for base/sft. Ignored for the turbo variant.",
+          "max": 15.0,
+          "min": 1.0,
+          "name": "guidance_scale",
+          "title": "Guidance Scale",
+          "type": {
+            "type": "float"
+          }
+        },
+        {
+          "default": 3.0,
+          "description": "Shift parameter for the flow-matching timestep schedule (1.0, 2.0, or 3.0).",
+          "max": 3.0,
+          "min": 1.0,
+          "name": "shift",
+          "title": "Shift",
+          "type": {
+            "type": "float"
+          }
+        },
+        {
+          "default": -1,
+          "description": "Random seed for reproducible generation. Use -1 for random.",
+          "min": -1.0,
+          "name": "seed",
+          "title": "Seed",
+          "type": {
+            "type": "int"
+          }
+        },
+        {
+          "default": {
+            "asset_id": null,
+            "data": null,
+            "metadata": null,
+            "type": "audio",
+            "uri": ""
+          },
+          "description": "Audio (stereo, 48 kHz) to repaint. The region outside the range is kept.",
+          "name": "src_audio",
+          "title": "Source Audio",
+          "type": {
+            "type": "audio"
+          }
+        },
+        {
+          "default": 0.0,
+          "description": "Start time in seconds of the region to regenerate.",
+          "min": 0.0,
+          "name": "repainting_start",
+          "title": "Repaint Start",
+          "type": {
+            "type": "float"
+          }
+        },
+        {
+          "default": -1.0,
+          "description": "End time in seconds of the region to regenerate. Use -1 for until the end.",
+          "min": -1.0,
+          "name": "repainting_end",
+          "title": "Repaint End",
+          "type": {
+            "type": "float"
+          }
+        }
+      ],
+      "recommended_models": [
+        {
+          "allow_patterns": [
+            "*.safetensors",
+            "*.json",
+            "*.txt",
+            "*.model"
+          ],
+          "id": "ACE-Step/Ace-Step1.5",
+          "name": "ACE-Step/Ace-Step1.5",
+          "repo_id": "ACE-Step/Ace-Step1.5",
+          "type": "hf.text_to_audio"
+        },
+        {
+          "allow_patterns": [
+            "*.safetensors",
+            "*.json",
+            "*.txt",
+            "*.model"
+          ],
+          "id": "ACE-Step/acestep-v15-base",
+          "name": "ACE-Step/acestep-v15-base",
+          "repo_id": "ACE-Step/acestep-v15-base",
+          "type": "hf.text_to_audio"
+        },
+        {
+          "allow_patterns": [
+            "*.safetensors",
+            "*.json",
+            "*.txt",
+            "*.model"
+          ],
+          "id": "ACE-Step/acestep-v15-sft",
+          "name": "ACE-Step/acestep-v15-sft",
+          "repo_id": "ACE-Step/acestep-v15-sft",
+          "type": "hf.text_to_audio"
+        }
+      ],
+      "title": "ACE-Step Repaint"
+    },
+    {
+      "basic_fields": [
+        "src_audio",
+        "track_name"
+      ],
+      "input_fields": [
+        "prompt",
+        "src_audio"
+      ],
+      "description": "Extracts a single track (e.g. vocals, drums) from audio with ACE-Step 1.5.\n    audio, music, extract, stem-separation, vocals, drums, ace-step\n\n    Use cases:\n    - Isolate vocals, drums, bass, or other stems from a mix\n    - Build acapellas or instrumentals from a full track\n    - Prepare stems for remixing and sampling",
+      "namespace": "huggingface.text_to_audio",
+      "node_type": "huggingface.text_to_audio.AceStepExtract",
+      "body": "content_card",
+      "outputs": [
+        {
+          "name": "output",
+          "type": {
+            "type": "audio"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "default": "turbo",
+          "description": "DiT checkpoint to use. 'turbo' is guidance-distilled (8 steps, CFG ignored); 'base' and 'sft' use classifier-free guidance and benefit from more steps (30-60) for higher quality.",
+          "name": "variant",
+          "title": "Variant",
+          "type": {
+            "type": "enum",
+            "type_name": "nodetool.nodes.huggingface.text_to_audio.AceStepVariant",
+            "values": [
+              "turbo",
+              "base",
+              "sft"
+            ]
+          }
+        },
+        {
+          "default": "A beautiful piano piece with soft melodies and gentle rhythm",
+          "description": "Describe the music style, instruments, mood, and tempo (e.g., 'upbeat pop song with electric guitar and drums').",
+          "name": "prompt",
+          "title": "Prompt",
+          "type": {
+            "type": "str"
+          }
+        },
+        {
+          "default": "",
+          "description": "Lyrics for the song. Structure with tags like [verse], [chorus], [bridge]. Leave empty for instrumental music.",
+          "name": "lyrics",
+          "title": "Lyrics",
+          "type": {
+            "type": "str"
+          }
+        },
+        {
+          "default": "en",
+          "description": "Language code for the lyrics (e.g., 'en', 'zh', 'ja', 'ko', 'fr', 'de', 'es').",
+          "name": "vocal_language",
+          "title": "Vocal Language",
+          "type": {
+            "type": "str"
+          }
+        },
+        {
+          "default": 8,
+          "description": "Denoising steps. Turbo is tuned for 8; use 30-60 on base/sft for higher quality.",
+          "max": 200.0,
+          "min": 1.0,
+          "name": "num_inference_steps",
+          "title": "Num Inference Steps",
+          "type": {
+            "type": "int"
+          }
+        },
+        {
+          "default": 7.0,
+          "description": "Classifier-free guidance scale for base/sft. Ignored for the turbo variant.",
+          "max": 15.0,
+          "min": 1.0,
+          "name": "guidance_scale",
+          "title": "Guidance Scale",
+          "type": {
+            "type": "float"
+          }
+        },
+        {
+          "default": 3.0,
+          "description": "Shift parameter for the flow-matching timestep schedule (1.0, 2.0, or 3.0).",
+          "max": 3.0,
+          "min": 1.0,
+          "name": "shift",
+          "title": "Shift",
+          "type": {
+            "type": "float"
+          }
+        },
+        {
+          "default": -1,
+          "description": "Random seed for reproducible generation. Use -1 for random.",
+          "min": -1.0,
+          "name": "seed",
+          "title": "Seed",
+          "type": {
+            "type": "int"
+          }
+        },
+        {
+          "default": {
+            "asset_id": null,
+            "data": null,
+            "metadata": null,
+            "type": "audio",
+            "uri": ""
+          },
+          "description": "Audio (stereo, 48 kHz) to extract a track from.",
+          "name": "src_audio",
+          "title": "Source Audio",
+          "type": {
+            "type": "audio"
+          }
+        },
+        {
+          "default": "vocals",
+          "description": "Track to extract (e.g. 'vocals', 'drums', 'bass', 'guitar', 'piano').",
+          "name": "track_name",
+          "title": "Track Name",
+          "type": {
+            "type": "str"
+          }
+        }
+      ],
+      "recommended_models": [
+        {
+          "allow_patterns": [
+            "*.safetensors",
+            "*.json",
+            "*.txt",
+            "*.model"
+          ],
+          "id": "ACE-Step/Ace-Step1.5",
+          "name": "ACE-Step/Ace-Step1.5",
+          "repo_id": "ACE-Step/Ace-Step1.5",
+          "type": "hf.text_to_audio"
+        },
+        {
+          "allow_patterns": [
+            "*.safetensors",
+            "*.json",
+            "*.txt",
+            "*.model"
+          ],
+          "id": "ACE-Step/acestep-v15-base",
+          "name": "ACE-Step/acestep-v15-base",
+          "repo_id": "ACE-Step/acestep-v15-base",
+          "type": "hf.text_to_audio"
+        },
+        {
+          "allow_patterns": [
+            "*.safetensors",
+            "*.json",
+            "*.txt",
+            "*.model"
+          ],
+          "id": "ACE-Step/acestep-v15-sft",
+          "name": "ACE-Step/acestep-v15-sft",
+          "repo_id": "ACE-Step/acestep-v15-sft",
+          "type": "hf.text_to_audio"
+        }
+      ],
+      "title": "ACE-Step Extract"
+    },
+    {
+      "basic_fields": [
+        "src_audio",
+        "track_name",
+        "repainting_start",
+        "repainting_end"
+      ],
+      "input_fields": [
+        "prompt",
+        "src_audio"
+      ],
+      "description": "Generates a specific track conditioned on existing audio with ACE-Step 1.5 lego mode.\n    audio, music, lego, accompaniment, stem-generation, ace-step\n\n    Use cases:\n    - Add a new instrument track that fits an existing arrangement\n    - Generate a drum or bass line for a given musical context\n    - Regenerate a single track within a chosen time range",
+      "namespace": "huggingface.text_to_audio",
+      "node_type": "huggingface.text_to_audio.AceStepLego",
+      "body": "content_card",
+      "outputs": [
+        {
+          "name": "output",
+          "type": {
+            "type": "audio"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "default": "turbo",
+          "description": "DiT checkpoint to use. 'turbo' is guidance-distilled (8 steps, CFG ignored); 'base' and 'sft' use classifier-free guidance and benefit from more steps (30-60) for higher quality.",
+          "name": "variant",
+          "title": "Variant",
+          "type": {
+            "type": "enum",
+            "type_name": "nodetool.nodes.huggingface.text_to_audio.AceStepVariant",
+            "values": [
+              "turbo",
+              "base",
+              "sft"
+            ]
+          }
+        },
+        {
+          "default": "A beautiful piano piece with soft melodies and gentle rhythm",
+          "description": "Describe the music style, instruments, mood, and tempo (e.g., 'upbeat pop song with electric guitar and drums').",
+          "name": "prompt",
+          "title": "Prompt",
+          "type": {
+            "type": "str"
+          }
+        },
+        {
+          "default": "",
+          "description": "Lyrics for the song. Structure with tags like [verse], [chorus], [bridge]. Leave empty for instrumental music.",
+          "name": "lyrics",
+          "title": "Lyrics",
+          "type": {
+            "type": "str"
+          }
+        },
+        {
+          "default": "en",
+          "description": "Language code for the lyrics (e.g., 'en', 'zh', 'ja', 'ko', 'fr', 'de', 'es').",
+          "name": "vocal_language",
+          "title": "Vocal Language",
+          "type": {
+            "type": "str"
+          }
+        },
+        {
+          "default": 8,
+          "description": "Denoising steps. Turbo is tuned for 8; use 30-60 on base/sft for higher quality.",
+          "max": 200.0,
+          "min": 1.0,
+          "name": "num_inference_steps",
+          "title": "Num Inference Steps",
+          "type": {
+            "type": "int"
+          }
+        },
+        {
+          "default": 7.0,
+          "description": "Classifier-free guidance scale for base/sft. Ignored for the turbo variant.",
+          "max": 15.0,
+          "min": 1.0,
+          "name": "guidance_scale",
+          "title": "Guidance Scale",
+          "type": {
+            "type": "float"
+          }
+        },
+        {
+          "default": 3.0,
+          "description": "Shift parameter for the flow-matching timestep schedule (1.0, 2.0, or 3.0).",
+          "max": 3.0,
+          "min": 1.0,
+          "name": "shift",
+          "title": "Shift",
+          "type": {
+            "type": "float"
+          }
+        },
+        {
+          "default": -1,
+          "description": "Random seed for reproducible generation. Use -1 for random.",
+          "min": -1.0,
+          "name": "seed",
+          "title": "Seed",
+          "type": {
+            "type": "int"
+          }
+        },
+        {
+          "default": {
+            "asset_id": null,
+            "data": null,
+            "metadata": null,
+            "type": "audio",
+            "uri": ""
+          },
+          "description": "Audio (stereo, 48 kHz) providing the musical context.",
+          "name": "src_audio",
+          "title": "Source Audio",
+          "type": {
+            "type": "audio"
+          }
+        },
+        {
+          "default": "drums",
+          "description": "Track to generate (e.g. 'vocals', 'drums', 'bass', 'guitar', 'piano').",
+          "name": "track_name",
+          "title": "Track Name",
+          "type": {
+            "type": "str"
+          }
+        },
+        {
+          "default": 0.0,
+          "description": "Start time in seconds of the region to generate.",
+          "min": 0.0,
+          "name": "repainting_start",
+          "title": "Region Start",
+          "type": {
+            "type": "float"
+          }
+        },
+        {
+          "default": -1.0,
+          "description": "End time in seconds of the region to generate. Use -1 for until the end.",
+          "min": -1.0,
+          "name": "repainting_end",
+          "title": "Region End",
+          "type": {
+            "type": "float"
+          }
+        }
+      ],
+      "recommended_models": [
+        {
+          "allow_patterns": [
+            "*.safetensors",
+            "*.json",
+            "*.txt",
+            "*.model"
+          ],
+          "id": "ACE-Step/Ace-Step1.5",
+          "name": "ACE-Step/Ace-Step1.5",
+          "repo_id": "ACE-Step/Ace-Step1.5",
+          "type": "hf.text_to_audio"
+        },
+        {
+          "allow_patterns": [
+            "*.safetensors",
+            "*.json",
+            "*.txt",
+            "*.model"
+          ],
+          "id": "ACE-Step/acestep-v15-base",
+          "name": "ACE-Step/acestep-v15-base",
+          "repo_id": "ACE-Step/acestep-v15-base",
+          "type": "hf.text_to_audio"
+        },
+        {
+          "allow_patterns": [
+            "*.safetensors",
+            "*.json",
+            "*.txt",
+            "*.model"
+          ],
+          "id": "ACE-Step/acestep-v15-sft",
+          "name": "ACE-Step/acestep-v15-sft",
+          "repo_id": "ACE-Step/acestep-v15-sft",
+          "type": "hf.text_to_audio"
+        }
+      ],
+      "title": "ACE-Step Lego"
+    },
+    {
+      "basic_fields": [
+        "src_audio",
+        "complete_track_classes",
+        "prompt"
+      ],
+      "input_fields": [
+        "prompt",
+        "src_audio"
+      ],
+      "description": "Completes input audio with additional tracks using ACE-Step 1.5.\n    audio, music, complete, arrangement, accompaniment, ace-step\n\n    Use cases:\n    - Flesh out a sparse demo with extra instrument tracks\n    - Add accompaniment around a lead vocal or melody\n    - Turn a single stem into a fuller arrangement",
+      "namespace": "huggingface.text_to_audio",
+      "node_type": "huggingface.text_to_audio.AceStepComplete",
+      "body": "content_card",
+      "outputs": [
+        {
+          "name": "output",
+          "type": {
+            "type": "audio"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "default": "turbo",
+          "description": "DiT checkpoint to use. 'turbo' is guidance-distilled (8 steps, CFG ignored); 'base' and 'sft' use classifier-free guidance and benefit from more steps (30-60) for higher quality.",
+          "name": "variant",
+          "title": "Variant",
+          "type": {
+            "type": "enum",
+            "type_name": "nodetool.nodes.huggingface.text_to_audio.AceStepVariant",
+            "values": [
+              "turbo",
+              "base",
+              "sft"
+            ]
+          }
+        },
+        {
+          "default": "A beautiful piano piece with soft melodies and gentle rhythm",
+          "description": "Describe the music style, instruments, mood, and tempo (e.g., 'upbeat pop song with electric guitar and drums').",
+          "name": "prompt",
+          "title": "Prompt",
+          "type": {
+            "type": "str"
+          }
+        },
+        {
+          "default": "",
+          "description": "Lyrics for the song. Structure with tags like [verse], [chorus], [bridge]. Leave empty for instrumental music.",
+          "name": "lyrics",
+          "title": "Lyrics",
+          "type": {
+            "type": "str"
+          }
+        },
+        {
+          "default": "en",
+          "description": "Language code for the lyrics (e.g., 'en', 'zh', 'ja', 'ko', 'fr', 'de', 'es').",
+          "name": "vocal_language",
+          "title": "Vocal Language",
+          "type": {
+            "type": "str"
+          }
+        },
+        {
+          "default": 8,
+          "description": "Denoising steps. Turbo is tuned for 8; use 30-60 on base/sft for higher quality.",
+          "max": 200.0,
+          "min": 1.0,
+          "name": "num_inference_steps",
+          "title": "Num Inference Steps",
+          "type": {
+            "type": "int"
+          }
+        },
+        {
+          "default": 7.0,
+          "description": "Classifier-free guidance scale for base/sft. Ignored for the turbo variant.",
+          "max": 15.0,
+          "min": 1.0,
+          "name": "guidance_scale",
+          "title": "Guidance Scale",
+          "type": {
+            "type": "float"
+          }
+        },
+        {
+          "default": 3.0,
+          "description": "Shift parameter for the flow-matching timestep schedule (1.0, 2.0, or 3.0).",
+          "max": 3.0,
+          "min": 1.0,
+          "name": "shift",
+          "title": "Shift",
+          "type": {
+            "type": "float"
+          }
+        },
+        {
+          "default": -1,
+          "description": "Random seed for reproducible generation. Use -1 for random.",
+          "min": -1.0,
+          "name": "seed",
+          "title": "Seed",
+          "type": {
+            "type": "int"
+          }
+        },
+        {
+          "default": {
+            "asset_id": null,
+            "data": null,
+            "metadata": null,
+            "type": "audio",
+            "uri": ""
+          },
+          "description": "Audio (stereo, 48 kHz) to complete with additional tracks.",
+          "name": "src_audio",
+          "title": "Source Audio",
+          "type": {
+            "type": "audio"
+          }
+        },
+        {
+          "default": [],
+          "description": "Track classes to add (e.g. ['drums', 'bass', 'guitar']). Empty lets the model decide.",
+          "name": "complete_track_classes",
+          "title": "Track Classes",
+          "type": {
+            "type": "list",
+            "type_args": [
+              {
+                "type": "str"
+              }
+            ]
+          }
+        }
+      ],
+      "recommended_models": [
+        {
+          "allow_patterns": [
+            "*.safetensors",
+            "*.json",
+            "*.txt",
+            "*.model"
+          ],
+          "id": "ACE-Step/Ace-Step1.5",
+          "name": "ACE-Step/Ace-Step1.5",
+          "repo_id": "ACE-Step/Ace-Step1.5",
+          "type": "hf.text_to_audio"
+        },
+        {
+          "allow_patterns": [
+            "*.safetensors",
+            "*.json",
+            "*.txt",
+            "*.model"
+          ],
+          "id": "ACE-Step/acestep-v15-base",
+          "name": "ACE-Step/acestep-v15-base",
+          "repo_id": "ACE-Step/acestep-v15-base",
+          "type": "hf.text_to_audio"
+        },
+        {
+          "allow_patterns": [
+            "*.safetensors",
+            "*.json",
+            "*.txt",
+            "*.model"
+          ],
+          "id": "ACE-Step/acestep-v15-sft",
+          "name": "ACE-Step/acestep-v15-sft",
+          "repo_id": "ACE-Step/acestep-v15-sft",
+          "type": "hf.text_to_audio"
+        }
+      ],
+      "title": "ACE-Step Complete"
     },
     {
       "basic_fields": [

--- a/src/nodetool/package_metadata/nodetool-huggingface.json
+++ b/src/nodetool/package_metadata/nodetool-huggingface.json
@@ -13334,6 +13334,166 @@
     },
     {
       "basic_fields": [
+        "variant",
+        "prompt",
+        "lyrics",
+        "audio_duration"
+      ],
+      "input_fields": [
+        "prompt"
+      ],
+      "description": "Generates commercial-grade stereo music with lyrics using ACE-Step 1.5.\n    audio, music, generation, text-to-music, lyrics, stereo, ace-step, song\n\n    Use cases:\n    - Generate full songs with vocals from a style prompt and structured lyrics\n    - Produce 48 kHz stereo music in 50+ languages\n    - Create instrumental tracks, background music, and soundtracks\n    - Fast 8-step generation with the guidance-distilled turbo checkpoint",
+      "namespace": "huggingface.text_to_audio",
+      "node_type": "huggingface.text_to_audio.AceStep",
+      "body": "content_card",
+      "outputs": [
+        {
+          "name": "output",
+          "type": {
+            "type": "audio"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "default": "turbo",
+          "description": "DiT checkpoint to use. 'turbo' is guidance-distilled (8 steps, CFG ignored); 'base' and 'sft' use classifier-free guidance and benefit from more steps (30-60) for higher quality.",
+          "name": "variant",
+          "title": "Variant",
+          "type": {
+            "type": "enum",
+            "type_name": "nodetool.nodes.huggingface.text_to_audio.AceStepVariant",
+            "values": [
+              "turbo",
+              "base",
+              "sft"
+            ]
+          }
+        },
+        {
+          "default": "A beautiful piano piece with soft melodies and gentle rhythm",
+          "description": "Describe the music style, instruments, mood, and tempo (e.g., 'upbeat pop song with electric guitar and drums').",
+          "name": "prompt",
+          "title": "Prompt",
+          "type": {
+            "type": "str"
+          }
+        },
+        {
+          "default": "[verse]\nSoft notes in the morning light\nDancing through the air so bright\n[chorus]\nMusic fills the air tonight\nEvery note feels just right",
+          "description": "Lyrics for the song. Structure with tags like [verse], [chorus], [bridge]. Leave empty for instrumental music.",
+          "name": "lyrics",
+          "title": "Lyrics",
+          "type": {
+            "type": "str"
+          }
+        },
+        {
+          "default": 60.0,
+          "description": "Duration of the generated music in seconds (10 to 600).",
+          "max": 600.0,
+          "min": 10.0,
+          "name": "audio_duration",
+          "title": "Audio Duration",
+          "type": {
+            "type": "float"
+          }
+        },
+        {
+          "default": "en",
+          "description": "Language code for the lyrics (e.g., 'en', 'zh', 'ja', 'ko', 'fr', 'de', 'es').",
+          "name": "vocal_language",
+          "title": "Vocal Language",
+          "type": {
+            "type": "str"
+          }
+        },
+        {
+          "default": 8,
+          "description": "Denoising steps. Turbo is tuned for 8; use 30-60 on base/sft for higher quality.",
+          "max": 200.0,
+          "min": 1.0,
+          "name": "num_inference_steps",
+          "title": "Num Inference Steps",
+          "type": {
+            "type": "int"
+          }
+        },
+        {
+          "default": 7.0,
+          "description": "Classifier-free guidance scale for base/sft. Ignored for the turbo variant.",
+          "max": 15.0,
+          "min": 1.0,
+          "name": "guidance_scale",
+          "title": "Guidance Scale",
+          "type": {
+            "type": "float"
+          }
+        },
+        {
+          "default": 3.0,
+          "description": "Shift parameter for the flow-matching timestep schedule (1.0, 2.0, or 3.0).",
+          "max": 3.0,
+          "min": 1.0,
+          "name": "shift",
+          "title": "Shift",
+          "type": {
+            "type": "float"
+          }
+        },
+        {
+          "default": -1,
+          "description": "Random seed for reproducible generation. Use -1 for random.",
+          "min": -1.0,
+          "name": "seed",
+          "title": "Seed",
+          "type": {
+            "type": "int"
+          }
+        }
+      ],
+      "recommended_models": [
+        {
+          "allow_patterns": [
+            "*.safetensors",
+            "*.json",
+            "*.txt",
+            "*.model"
+          ],
+          "id": "ACE-Step/Ace-Step1.5",
+          "name": "ACE-Step/Ace-Step1.5",
+          "repo_id": "ACE-Step/Ace-Step1.5",
+          "type": "hf.text_to_audio"
+        },
+        {
+          "allow_patterns": [
+            "*.safetensors",
+            "*.json",
+            "*.txt",
+            "*.model"
+          ],
+          "id": "ACE-Step/acestep-v15-base",
+          "name": "ACE-Step/acestep-v15-base",
+          "repo_id": "ACE-Step/acestep-v15-base",
+          "type": "hf.text_to_audio"
+        },
+        {
+          "allow_patterns": [
+            "*.safetensors",
+            "*.json",
+            "*.txt",
+            "*.model"
+          ],
+          "id": "ACE-Step/acestep-v15-sft",
+          "name": "ACE-Step/acestep-v15-sft",
+          "repo_id": "ACE-Step/acestep-v15-sft",
+          "type": "hf.text_to_audio"
+        }
+      ],
+      "title": "ACE-Step 1.5"
+    },
+    {
+      "basic_fields": [
         "prompt",
         "height",
         "width",


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for ACE-Step 1.5, a commercial-grade text-to-audio model, by implementing six new node types that cover different music generation and manipulation tasks.

## Key Changes

- **New AceStepVariant enum**: Defines three checkpoint variants (turbo, base, sft) with different quality/speed tradeoffs
- **AceStepBaseNode**: Shared base class implementing common functionality:
  - Conditioning fields (prompt, lyrics, vocal_language)
  - Sampling controls (num_inference_steps, guidance_scale, shift, seed)
  - Pipeline loading and audio tensor conversion utilities
  - Guidance scale resolution (turbo variant ignores CFG)

- **Six specialized task nodes**:
  - `AceStep`: Full song generation from text prompts and lyrics (10-600 second duration)
  - `AceStepCover`: Timbre transfer and voice conversion using reference audio
  - `AceStepRepaint`: Inpainting/regeneration of specific time ranges in existing audio
  - `AceStepExtract`: Stem separation to isolate individual tracks (vocals, drums, etc.)
  - `AceStepLego`: Conditional track generation that fits existing musical context
  - `AceStepComplete`: Arrangement completion by adding complementary instrument tracks

- **Metadata configuration**: Updated `nodetool-huggingface.json` with complete node definitions, properties, recommended models, and use case descriptions for all six nodes

## Implementation Details

- All nodes inherit from `AceStepBaseNode` to share pipeline management and audio processing logic
- Audio I/O uses stereo tensors at 48 kHz sample rate with automatic mono-to-stereo conversion
- Progress callbacks integrated for real-time generation feedback
- Seed support for reproducible generation (-1 for random)
- Proper garbage collection after inference to manage memory
- Task-specific parameters passed through `_run()` method with `task_type` routing

https://claude.ai/code/session_01Rx7gJAAEfuoJ9P6Pi4stq9